### PR TITLE
Handle Firebase init errors

### DIFF
--- a/config/FirebaseConfig.ts
+++ b/config/FirebaseConfig.ts
@@ -1,8 +1,8 @@
 // Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
-import { getAuth, initializeAuth, getReactNativePersistence } from "firebase/auth";
+import { initializeApp, FirebaseApp } from "firebase/app";
+import { initializeAuth, getReactNativePersistence, Auth } from "firebase/auth";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { getFirestore } from "firebase/firestore";
+import { getFirestore, Firestore } from "firebase/firestore";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -30,12 +30,20 @@ const firebaseConfig = {
     process.env.FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize Firebase
-export const app = initializeApp(firebaseConfig);
-// export const auth = getAuth(app);
-export const auth = initializeAuth(app, {
-  persistence: getReactNativePersistence(AsyncStorage),
-});
+let app: FirebaseApp | undefined;
+let auth: Auth | undefined;
+let db: Firestore | undefined;
 
-export const db = getFirestore(app);
+try {
+  // Initialize Firebase only if configuration is valid
+  app = initializeApp(firebaseConfig);
+  auth = initializeAuth(app, {
+    persistence: getReactNativePersistence(AsyncStorage),
+  });
+  db = getFirestore(app);
+} catch (error) {
+  console.error("Error initializing Firebase:", error);
+}
+
+export { app, auth, db };
 


### PR DESCRIPTION
## Summary
- add defensive Firebase initialization that logs and ignores config errors

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`
- `npm run lint --silent` *(fails: ESLint is not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68906f875330832481023672644a1462