### PR TITLE
Handle Firebase init errors

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -22,6 +22,11 @@ const SignIn = () => {
         return;
       }
 
+      if (!auth) {
+        alert("Firebase not initialized");
+        return;
+      }
+
       const userCredential = await signInWithEmailAndPassword(
         auth,
         form.email,

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -23,6 +23,11 @@ const SignUp = () => {
         return;
       }
 
+      if (!auth) {
+        alert("Firebase not initialized");
+        return;
+      }
+
       const userCredential = await createUserWithEmailAndPassword(
         auth,
         form.email,

--- a/app/(tabs)/mytrip.tsx
+++ b/app/(tabs)/mytrip.tsx
@@ -16,7 +16,7 @@ import { useRouter } from "expo-router";
 
 const MyTrip = () => {
   const [userTrips, setUserTrips] = useState<any[]>([]);
-  const user = auth.currentUser;
+  const user = auth?.currentUser;
   const [loading, setLoading] = useState(false);
   const router = useRouter();
 
@@ -25,11 +25,12 @@ const MyTrip = () => {
   }, [user]);
 
   const getMyTrips = async () => {
+    if (!db || !user) return;
     setLoading(true);
     setUserTrips([]);
     const q = query(
       collection(db, "UserTrips"),
-      where("userEmail", "==", user?.email)
+      where("userEmail", "==", user.email)
     );
     const querySnapshot = await getDocs(q);
 

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -7,12 +7,14 @@ import { Ionicons } from "@expo/vector-icons";
 import CustomButton from "@/components/CustomButton";
 
 const Profile = () => {
-  const user = auth.currentUser;
+  const user = auth?.currentUser;
 
   const handleLogout = async () => {
     try {
-      await auth.signOut();
-      router.replace("/(auth)/welcome");
+      if (auth) {
+        await auth.signOut();
+        router.replace("/(auth)/welcome");
+      }
     } catch (error) {
       console.error("Error signing out:", error);
     }
@@ -32,7 +34,9 @@ const Profile = () => {
             <Text className="text-xl font-outfit-bold">{user?.email}</Text>
             <Text className="text-gray-600 font-outfit">
               Member since{" "}
-              {new Date(user?.metadata.creationTime!).getFullYear()}
+              {user?.metadata?.creationTime
+                ? new Date(user.metadata.creationTime).getFullYear()
+                : ""}
             </Text>
           </View>
         </View>
@@ -55,7 +59,9 @@ const Profile = () => {
             <Text className="ml-3 font-outfit">Last Sign In</Text>
           </View>
           <Text className="text-gray-500 font-outfit">
-            {new Date(user?.metadata.lastSignInTime!).toLocaleDateString()}
+            {user?.metadata?.lastSignInTime
+              ? new Date(user.metadata.lastSignInTime).toLocaleDateString()
+              : ""}
           </Text>
         </TouchableOpacity>
       </View>

--- a/app/generate-trip.tsx
+++ b/app/generate-trip.tsx
@@ -11,7 +11,7 @@ import { auth, db } from "@/config/FirebaseConfig";
 const GenerateTrip = () => {
   const { tripData } = useContext(CreateTripContext);
   const [loading, setLoading] = useState(false);
-  const user = auth.currentUser;
+  const user = auth?.currentUser;
 
   const router = useRouter();
 
@@ -50,14 +50,16 @@ const GenerateTrip = () => {
 
     const docId = Date.now().toString();
 
-    const res = await setDoc(doc(db, "UserTrips", docId), {
-      userEmail: user?.email,
-      tripPlan: tripResponse,
-      tripData: JSON.stringify(tripData),
-      docId: docId,
-    });
+    if (db && user) {
+      await setDoc(doc(db, "UserTrips", docId), {
+        userEmail: user.email,
+        tripPlan: tripResponse,
+        tripData: JSON.stringify(tripData),
+        docId: docId,
+      });
 
-    router.push("/mytrip");
+      router.push("/mytrip");
+    }
   };
 
   return (

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -6,9 +6,13 @@ import { onAuthStateChanged } from "firebase/auth";
 
 export default function HomeScreen() {
   const [isLoading, setIsLoading] = useState(true);
-  const [user, setUser] = useState(auth.currentUser);
+  const [user, setUser] = useState(auth?.currentUser ?? null);
 
   useEffect(() => {
+    if (!auth) {
+      setIsLoading(false);
+      return;
+    }
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       setUser(user);
       setIsLoading(false);

--- a/config/FirebaseConfig.ts
+++ b/config/FirebaseConfig.ts
@@ -1,8 +1,8 @@
 // Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
-import { getAuth, initializeAuth, getReactNativePersistence } from "firebase/auth";
+import { initializeApp, FirebaseApp } from "firebase/app";
+import { initializeAuth, getReactNativePersistence, Auth } from "firebase/auth";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { getFirestore } from "firebase/firestore";
+import { getFirestore, Firestore } from "firebase/firestore";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -30,12 +30,20 @@ const firebaseConfig = {
     process.env.FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize Firebase
-export const app = initializeApp(firebaseConfig);
-// export const auth = getAuth(app);
-export const auth = initializeAuth(app, {
-  persistence: getReactNativePersistence(AsyncStorage),
-});
+let app: FirebaseApp | undefined;
+let auth: Auth | undefined;
+let db: Firestore | undefined;
 
-export const db = getFirestore(app);
+try {
+  // Initialize Firebase only if configuration is valid
+  app = initializeApp(firebaseConfig);
+  auth = initializeAuth(app, {
+    persistence: getReactNativePersistence(AsyncStorage),
+  });
+  db = getFirestore(app);
+} catch (error) {
+  console.error("Error initializing Firebase:", error);
+}
+
+export { app, auth, db };
 


### PR DESCRIPTION
## Summary
- add defensive Firebase initialization that logs and ignores config errors
- guard all auth and Firestore usage when Firebase fails to initialize

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`
- `npm run lint --silent` *(fails: ESLint is not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68906f875330832481023672644a1462