### PR TITLE
Handle incomplete trip data to avoid crashes

### DIFF
--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -1,12 +1,25 @@
 import { View, Text, ScrollView, Image, Linking } from "react-native";
 import React, { useEffect, useState } from "react";
 import { useLocalSearchParams } from "expo-router";
-import moment from "moment";
-import { Ionicons, MaterialIcons } from "@expo/vector-icons";
+import { Ionicons } from "@expo/vector-icons";
 import CustomButton from "@/components/CustomButton";
 
 const DEFAULT_IMAGE_URL =
   "https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?q=80&w=2071&auto=format&fit=crop";
+
+const toDate = (value: any) => {
+  if (!value) return undefined;
+  if (typeof value === "string" || typeof value === "number") {
+    return new Date(value);
+  }
+  if (value.seconds) {
+    return new Date(value.seconds * 1000);
+  }
+  if (value._seconds) {
+    return new Date(value._seconds * 1000);
+  }
+  return undefined;
+};
 
 const Discover = () => {
   const { tripData, tripPlan } = useLocalSearchParams();
@@ -18,13 +31,13 @@ const Discover = () => {
       const response = await fetch(
         `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${encodeURIComponent(
           placeName
-        )}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAP_KEY}`
+        )}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`
       );
       const data = await response.json();
 
       if (data.results && data.results[0] && data.results[0].photos) {
         const photoReference = data.results[0].photos[0].photo_reference;
-        return `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${photoReference}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAP_KEY}`;
+        return `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${photoReference}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`;
       }
       return DEFAULT_IMAGE_URL;
     } catch (error) {
@@ -36,11 +49,12 @@ const Discover = () => {
   useEffect(() => {
     if (tripData && tripPlan) {
       const parsedTrip = JSON.parse(tripPlan as string);
-      setParsedTripData(JSON.parse(tripData as string));
+      const parsedData = JSON.parse(tripData as string);
+      setParsedTripData(parsedData);
       setParsedTripPlan(parsedTrip);
 
       // Fetch images for hotels
-      parsedTrip.trip_plan.hotel.options.forEach(
+      parsedTrip?.trip_plan?.hotel?.options?.forEach(
         async (hotel: any, index: number) => {
           const imageUrl = await fetchPlaceImage(hotel.name);
           setParsedTripPlan((prev: any) => ({
@@ -59,7 +73,7 @@ const Discover = () => {
       );
 
       // Fetch images for places to visit
-      parsedTrip.trip_plan.places_to_visit.forEach(
+      parsedTrip?.trip_plan?.places_to_visit?.forEach(
         async (place: any, index: number) => {
           const imageUrl = await fetchPlaceImage(place.name);
           setParsedTripPlan((prev: any) => ({
@@ -107,10 +121,10 @@ const Discover = () => {
       <View className="bg-purple-50 p-4 rounded-xl mb-6">
         <Text className="font-outfit-bold text-lg mb-2">Trip Overview</Text>
         <Text className="font-outfit text-gray-600">
-          Duration: {parsedTripPlan.trip_plan.duration}
+          Duration: {parsedTripPlan?.trip_plan?.duration ?? "N/A"}
         </Text>
         <Text className="font-outfit text-gray-600">
-          Budget: {parsedTripPlan.trip_plan.budget}
+          Budget: {parsedTripPlan?.trip_plan?.budget ?? "N/A"}
         </Text>
         {/* <Text className="font-outfit text-gray-600">
           Group Size: {parsedTripPlan.group_size}
@@ -120,127 +134,153 @@ const Discover = () => {
       {/* Flight Details */}
       <View className="mb-8">
         <Text className="text-2xl font-outfit-bold mb-4">Flight Details</Text>
-        <View className="bg-gray-50 p-4 rounded-xl border border-gray-100">
-          <View className="flex-row justify-between items-center mb-4">
-            <View>
-              <Text className="font-outfit-bold text-lg">
-                {parsedTripPlan.trip_plan.flight_details.departure_city}
-              </Text>
-              <Text className="font-outfit text-gray-600">
-                {parsedTripPlan.trip_plan.flight_details.departure_date}{" "}
-                {parsedTripPlan.trip_plan.flight_details.departure_time}
-              </Text>
+        {parsedTripPlan?.trip_plan?.flight_details ? (
+          <View className="bg-gray-50 p-4 rounded-xl border border-gray-100">
+            <View className="flex-row justify-between items-center mb-4">
+              <View>
+                <Text className="font-outfit-bold text-lg">
+                  {parsedTripPlan.trip_plan.flight_details.departure_city}
+                </Text>
+                <Text className="font-outfit text-gray-600">
+                  {
+                    toDate(
+                      parsedTripPlan.trip_plan.flight_details.departure_date
+                    )?.toLocaleDateString() || ""
+                  }{" "}
+                  {parsedTripPlan.trip_plan.flight_details.departure_time}
+                </Text>
+              </View>
+              <Ionicons name="airplane" size={24} color="#8b5cf6" />
+              <View>
+                <Text className="font-outfit-bold text-lg">
+                  {parsedTripPlan.trip_plan.flight_details.arrival_city}
+                </Text>
+                <Text className="font-outfit text-gray-600">
+                  {
+                    toDate(
+                      parsedTripPlan.trip_plan.flight_details.arrival_date
+                    )?.toLocaleDateString() || ""
+                  }{" "}
+                  {parsedTripPlan.trip_plan.flight_details.arrival_time}
+                </Text>
+              </View>
             </View>
-            <Ionicons name="airplane" size={24} color="#8b5cf6" />
-            <View>
-              <Text className="font-outfit-bold text-lg">
-                {parsedTripPlan.trip_plan.flight_details.arrival_city}
+            <View className="border-t border-gray-200 pt-4">
+              <Text className="font-outfit text-gray-600">
+                Airline: {parsedTripPlan.trip_plan.flight_details.airline}
               </Text>
               <Text className="font-outfit text-gray-600">
-                {parsedTripPlan.trip_plan.flight_details.arrival_date}{" "}
-                {parsedTripPlan.trip_plan.flight_details.arrival_time}
-              </Text>
-            </View>
-          </View>
-          <View className="border-t border-gray-200 pt-4">
-            <Text className="font-outfit text-gray-600">
-              Airline: {parsedTripPlan.trip_plan.flight_details.airline}
-            </Text>
-            <Text className="font-outfit text-gray-600">
-              Flight: {parsedTripPlan.trip_plan.flight_details.flight_number}
-            </Text>
-            <Text className="font-outfit text-gray-600">
-              Price: {parsedTripPlan.trip_plan.flight_details.price}
-            </Text>
-            <CustomButton
-              title="Book Flight"
-              onPress={() =>
-                Linking.openURL(
-                  parsedTripPlan.trip_plan.flight_details.booking_url
-                )
-              }
-              className="mt-4"
-            />
-          </View>
-        </View>
-      </View>
-
-      {/* Hotels Section */}
-      <View className="mb-8">
-        <Text className="text-2xl font-outfit-bold mb-4">Hotel Options</Text>
-        {parsedTripPlan.trip_plan.hotel.options.map(
-          (hotel: any, index: number) => (
-            <View
-              key={index}
-              className="bg-gray-50 p-4 rounded-xl mb-4 border border-gray-100"
-            >
-              <Image
-                source={{ uri: hotel.image_url }}
-                className="w-full h-48 rounded-xl mb-4"
-              />
-              <Text className="font-outfit-bold text-lg">{hotel.name}</Text>
-              <Text className="font-outfit text-gray-600 mb-2">
-                {hotel.address}
+                Flight: {parsedTripPlan.trip_plan.flight_details.flight_number}
               </Text>
               <Text className="font-outfit text-gray-600">
-                Price: {hotel.price}
-              </Text>
-              <Text className="font-outfit text-gray-600">
-                Rating: {hotel.rating} ⭐
-              </Text>
-              <Text className="font-outfit text-gray-600 mt-2">
-                {hotel.description}
+                Price: {parsedTripPlan.trip_plan.flight_details.price}
               </Text>
               <CustomButton
-                title="View on Map"
+                title="Book Flight"
                 onPress={() =>
-                  handleOpenMap(
-                    hotel.geo_coordinates.latitude,
-                    hotel.geo_coordinates.longitude
+                  Linking.openURL(
+                    parsedTripPlan.trip_plan.flight_details.booking_url
                   )
                 }
                 className="mt-4"
               />
             </View>
+          </View>
+        ) : (
+          <Text className="font-outfit text-gray-600">
+            No flight details available.
+          </Text>
+        )}
+      </View>
+
+      {/* Hotels Section */}
+      <View className="mb-8">
+        <Text className="text-2xl font-outfit-bold mb-4">Hotel Options</Text>
+        {parsedTripPlan?.trip_plan?.hotel?.options?.length ? (
+          parsedTripPlan.trip_plan.hotel.options.map(
+            (hotel: any, index: number) => (
+              <View
+                key={index}
+                className="bg-gray-50 p-4 rounded-xl mb-4 border border-gray-100"
+              >
+                <Image
+                  source={{ uri: hotel.image_url }}
+                  className="w-full h-48 rounded-xl mb-4"
+                />
+                <Text className="font-outfit-bold text-lg">{hotel.name}</Text>
+                <Text className="font-outfit text-gray-600 mb-2">
+                  {hotel.address}
+                </Text>
+                <Text className="font-outfit text-gray-600">
+                  Price: {hotel.price}
+                </Text>
+                <Text className="font-outfit text-gray-600">
+                  Rating: {hotel.rating} ⭐
+                </Text>
+                <Text className="font-outfit text-gray-600 mt-2">
+                  {hotel.description}
+                </Text>
+                <CustomButton
+                  title="View on Map"
+                  onPress={() =>
+                    handleOpenMap(
+                      hotel.geo_coordinates.latitude,
+                      hotel.geo_coordinates.longitude
+                    )
+                  }
+                  className="mt-4"
+                />
+              </View>
+            )
           )
+        ) : (
+          <Text className="font-outfit text-gray-600">
+            No hotel options available.
+          </Text>
         )}
       </View>
 
       {/* Places to Visit */}
       <View className="mb-8">
         <Text className="text-2xl font-outfit-bold mb-4">Places to Visit</Text>
-        {parsedTripPlan.trip_plan.places_to_visit.map(
-          (place: any, index: number) => (
-            <View
-              key={index}
-              className="bg-gray-50 p-4 rounded-xl mb-4 border border-gray-100"
-            >
-              <Image
-                source={{ uri: place.image_url }}
-                className="w-full h-48 rounded-xl mb-4"
-              />
-              <Text className="font-outfit-bold text-lg">{place.name}</Text>
-              <Text className="font-outfit text-gray-600 mb-2">
-                {place.details}
-              </Text>
-              <Text className="font-outfit text-gray-600">
-                Ticket Price: {place.ticket_price}
-              </Text>
-              <Text className="font-outfit text-gray-600">
-                Time to Travel: {place.time_to_travel}
-              </Text>
-              <CustomButton
-                title="View on Map"
-                onPress={() =>
-                  handleOpenMap(
-                    place.geo_coordinates.latitude,
-                    place.geo_coordinates.longitude
-                  )
-                }
-                className="mt-4"
-              />
-            </View>
+        {parsedTripPlan?.trip_plan?.places_to_visit?.length ? (
+          parsedTripPlan.trip_plan.places_to_visit.map(
+            (place: any, index: number) => (
+              <View
+                key={index}
+                className="bg-gray-50 p-4 rounded-xl mb-4 border border-gray-100"
+              >
+                <Image
+                  source={{ uri: place.image_url }}
+                  className="w-full h-48 rounded-xl mb-4"
+                />
+                <Text className="font-outfit-bold text-lg">{place.name}</Text>
+                <Text className="font-outfit text-gray-600 mb-2">
+                  {place.details}
+                </Text>
+                <Text className="font-outfit text-gray-600">
+                  Ticket Price: {place.ticket_price}
+                </Text>
+                <Text className="font-outfit text-gray-600">
+                  Time to Travel: {place.time_to_travel}
+                </Text>
+                <CustomButton
+                  title="View on Map"
+                  onPress={() =>
+                    handleOpenMap(
+                      place.geo_coordinates.latitude,
+                      place.geo_coordinates.longitude
+                    )
+                  }
+                  className="mt-4"
+                />
+              </View>
+            )
           )
+        ) : (
+          <Text className="font-outfit text-gray-600">
+            No places to visit available.
+          </Text>
         )}
       </View>
     </ScrollView>

--- a/app/(tabs)/mytrip.tsx
+++ b/app/(tabs)/mytrip.tsx
@@ -35,7 +35,15 @@ export default function MyTrip() {
     const querySnapshot = await getDocs(q);
 
     querySnapshot.forEach((doc) => {
-      setUserTrips((prev) => [...prev, doc.data()]);
+      const data = doc.data();
+      const plan = data.tripPlan?.trip_plan;
+      if (
+        plan?.flight_details?.departure_city &&
+        plan?.hotel?.options?.length &&
+        plan?.places_to_visit?.length
+      ) {
+        setUserTrips((prev) => [...prev, data]);
+      }
     });
     setLoading(false);
   };

--- a/app/generate-trip.tsx
+++ b/app/generate-trip.tsx
@@ -10,6 +10,21 @@ import { useRouter } from "expo-router";
 import { doc, setDoc } from "firebase/firestore";
 import { auth, db } from "@/config/FirebaseConfig";
 
+const formatDate = (value: any) => {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number") {
+    return new Date(value).toISOString().split("T")[0];
+  }
+  if (value.seconds) {
+    return new Date(value.seconds * 1000).toISOString().split("T")[0];
+  }
+  if (value._seconds) {
+    return new Date(value._seconds * 1000).toISOString().split("T")[0];
+  }
+  return "";
+};
+
 export default function GenerateTrip() {
   const { tripData } = useContext(CreateTripContext);
   const [error, setError] = useState<string | null>(null);
@@ -18,6 +33,7 @@ export default function GenerateTrip() {
 
   useEffect(() => {
     generateTrip();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const generateTrip = async () => {
@@ -46,24 +62,139 @@ export default function GenerateTrip() {
         )
         .replace("{budget}", budget?.type || "");
 
-      // Create a new chat session with that prompt
-      const session = startChatSession([
-        { role: "user", parts: [{ text: FINAL_PROMPT }] },
-      ]);
+      // Helper to extract JSON from possible extra text
+      const extractJSON = (text: string) => {
+        const match = text.match(/\{[\s\S]*\}/);
+        if (match) {
+          return JSON.parse(match[0]);
+        }
+        throw new Error("Invalid response format");
+      };
 
-      // Send the prompt and await the response
-      const result = await session.sendMessage(FINAL_PROMPT);
-      const rawText = await result.response.text();
-      const parsed = JSON.parse(rawText);
-      // Unwrap the inner trip_plan object if present
-      const tripResponse = parsed.trip_plan ?? parsed;
+      // Normalize various AI response formats into our expected structure
+      const normalizeTripPlan = (data: any) => {
+        const root = data.trip_plan || data;
+        let flight =
+          root.flight_details || root.flights || data.flight_details || data.flights;
 
-      // Save to Firestore
+        if (Array.isArray(flight)) {
+          flight = flight[0];
+        }
+
+        const hotels =
+          root.hotel?.options ||
+          root.hotel_options ||
+          root.hotels ||
+          data.hotel?.options ||
+          data.hotel_options ||
+          data.hotels;
+        const places =
+          root.places_to_visit ||
+          root.places ||
+          root.sightseeing ||
+          data.places_to_visit ||
+          data.places ||
+          data.sightseeing;
+
+        const startDateStr = formatDate(dates?.startDate);
+
+        const filledFlight = {
+          departure_city: flight?.departure_city || "TBD",
+          arrival_city: flight?.arrival_city || locationInfo?.name || "",
+          departure_date: formatDate(flight?.departure_date) || startDateStr,
+          departure_time: flight?.departure_time || "",
+          arrival_date: formatDate(flight?.arrival_date) || startDateStr,
+          arrival_time: flight?.arrival_time || "",
+          airline: flight?.airline || "Unknown Airline",
+          flight_number: flight?.flight_number || "",
+          price: flight?.price || "",
+          booking_url: flight?.booking_url || "",
+        };
+
+        return {
+          trip_plan: {
+            ...root,
+            flight_details: filledFlight,
+            hotel: { options: hotels || [] },
+            places_to_visit: places || [],
+          },
+        };
+      };
+
+      // Try multiple times to obtain a complete trip plan
+      const MAX_RETRIES = 5;
+      let attempt = 0;
+      let prompt = FINAL_PROMPT;
+      let parsed: any = null;
+
+      while (attempt < MAX_RETRIES) {
+        try {
+          const session = startChatSession([
+            { role: "user", parts: [{ text: prompt }] },
+          ]);
+          const result = await session.sendMessage(prompt);
+          const rawText = await result.response.text();
+
+          try {
+            parsed = normalizeTripPlan(extractJSON(rawText));
+          } catch (err) {
+            console.error("parse error", err);
+            throw new Error("Invalid response format");
+          }
+        } catch (err) {
+          if (err instanceof Error && err.message.includes("503")) {
+            attempt++;
+            if (attempt >= MAX_RETRIES) {
+              throw new Error("AI service is overloaded. Please try again later.");
+            }
+            await new Promise((res) => setTimeout(res, attempt * 1000));
+            continue; // retry after delay
+          }
+          throw err;
+        }
+
+        const tripPlan = parsed?.trip_plan;
+        const missing: string[] = [];
+
+        const hotelOpts = tripPlan?.hotel?.options;
+        if (
+          !Array.isArray(hotelOpts) ||
+          hotelOpts.length === 0 ||
+          hotelOpts.some((h: any) => !h?.name)
+        ) {
+          missing.push("hotel options");
+        }
+
+        const places = tripPlan?.places_to_visit;
+        if (
+          !Array.isArray(places) ||
+          places.length === 0 ||
+          places.some((p: any) => !p?.name)
+        ) {
+          missing.push("places to visit");
+        }
+
+        if (missing.length === 0) {
+          break; // complete plan obtained
+        }
+
+        attempt++;
+        if (attempt >= MAX_RETRIES) {
+          throw new Error(
+            `Incomplete trip plan received: missing ${missing.join(", ")}`
+          );
+        }
+
+        // Ask the AI again for the missing sections
+        prompt = `The previous response was missing ${missing.join(", ")}. Please resend the entire trip plan in valid JSON including flight_details object, hotel options array, and places_to_visit array.`;
+      }
+
+      // Save the entire parsed response so downstream screens receive trip_plan
       const docId = Date.now().toString();
       if (db && user) {
         await setDoc(doc(db, "UserTrips", docId), {
           userEmail: user.email,
-          tripPlan: tripResponse,
+          tripPlan: parsed,
           tripData: JSON.stringify(tripData),
           docId,
         });
@@ -73,7 +204,15 @@ export default function GenerateTrip() {
       }
     } catch (err) {
       console.error("Failed to generate trip", err);
-      setError("Failed to generate trip. Please try again.");
+      if (err instanceof Error && err.message.includes("503")) {
+        setError("AI service is overloaded. Please try again later.");
+      } else {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to generate trip. Please try again."
+        );
+      }
     }
   };
 

--- a/app/trip-details/index.tsx
+++ b/app/trip-details/index.tsx
@@ -4,44 +4,66 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import moment from "moment";
 import CustomButton from "@/components/CustomButton";
 
+const DEFAULT_IMAGE_URL =
+  "https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?q=80&w=2071&auto=format&fit=crop";
+
+const toDate = (value: any) => {
+  if (!value) return undefined;
+  if (typeof value === "string" || typeof value === "number") {
+    return new Date(value);
+  }
+  if (value.seconds) {
+    return new Date(value.seconds * 1000);
+  }
+  if (value._seconds) {
+    return new Date(value._seconds * 1000);
+  }
+  return undefined;
+};
+
 const TripDetails = () => {
   const router = useRouter();
   const { tripData, tripPlan } = useLocalSearchParams();
 
-  const parsedTripData = JSON.parse(tripData as string);
-  const parsedTripPlan = JSON.parse(tripPlan as string);
+  const parsedTripData = tripData ? JSON.parse(tripData as string) : null;
+  const parsedTripPlan = tripPlan ? JSON.parse(tripPlan as string) : null;
 
   const locationInfo = parsedTripData?.find(
     (item: any) => item.locationInfo
   )?.locationInfo;
-  const startDate = parsedTripData?.find((item: any) => item.dates)?.dates
-    ?.startDate;
-  const endDate = parsedTripData?.find((item: any) => item.dates)?.dates
-    ?.endDate;
+  const startDate = toDate(
+    parsedTripData?.find((item: any) => item.dates)?.dates?.startDate
+  );
+  const endDate = toDate(
+    parsedTripData?.find((item: any) => item.dates)?.dates?.endDate
+  );
   const travelers = parsedTripData?.find(
     (item: any) => item.travelers
   )?.travelers;
-  const totalNumberOfDays = moment(endDate).diff(startDate, "days") + 1;
+  const totalNumberOfDays =
+    startDate && endDate ? moment(endDate).diff(startDate, "days") + 1 : 0;
   const budget = parsedTripData?.find((item: any) => item.budget)?.budget?.type;
 
   return (
     <ScrollView className="flex-1 bg-white">
       <Image
         source={{
-          uri: `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo?.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAP_KEY}`,
+          uri: locationInfo?.photoRef
+            ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`
+            : DEFAULT_IMAGE_URL,
         }}
         className="w-full h-72"
       />
 
       <View className="p-6">
         <Text className="text-3xl font-outfit-bold">
-          {parsedTripPlan?.trip_plan?.location}
+          {parsedTripPlan?.trip_plan?.location ?? "Unknown"}
         </Text>
 
         <View className="mt-4 space-y-2">
           <Text className="text-lg font-outfit text-gray-600">
-            {moment(startDate).format("MMM D")} -{" "}
-            {moment(endDate).format("MMM D, YYYY")}
+            {startDate ? moment(startDate).format("MMM D") : ""} -{" "}
+            {endDate ? moment(endDate).format("MMM D, YYYY") : ""}
           </Text>
           <Text className="text-lg font-outfit text-gray-600">
             Total Number of Days: {totalNumberOfDays}
@@ -50,7 +72,7 @@ const TripDetails = () => {
             {travelers?.type} ({travelers?.count})
           </Text>
           <Text className="text-lg font-outfit text-gray-600">
-            Budget Type: {budget}
+            Budget Type: {budget ?? "N/A"}
           </Text>
           <View className="flex mt-10 items-center justify-center">
             <Text className="text-lg font-outfit-medium text-gray-600">

--- a/components/GooglePlacesAutocomplete.tsx
+++ b/components/GooglePlacesAutocomplete.tsx
@@ -16,7 +16,7 @@ type Props = {
   onPlaceSelected: (place: { id: string; title: string }) => void;
 };
 
-const YOUR_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAP_KEY;
+const YOUR_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
 
 export default function GooglePlacesAutocomplete({ onPlaceSelected }: Props) {
   const [query, setQuery] = useState("");

--- a/components/MyTrips/UserTripCard.tsx
+++ b/components/MyTrips/UserTripCard.tsx
@@ -4,6 +4,23 @@ import moment from "moment";
 import CustomButton from "../CustomButton";
 import { useRouter } from "expo-router";
 
+const DEFAULT_IMAGE_URL =
+  "https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?q=80&w=2071&auto=format&fit=crop";
+
+const toDate = (value: any) => {
+  if (!value) return undefined;
+  if (typeof value === "string" || typeof value === "number") {
+    return new Date(value);
+  }
+  if (value.seconds) {
+    return new Date(value.seconds * 1000);
+  }
+  if (value._seconds) {
+    return new Date(value._seconds * 1000);
+  }
+  return undefined;
+};
+
 const UserTripCard = ({ trip }: { trip: any }) => {
   const router = useRouter();
 
@@ -11,17 +28,21 @@ const UserTripCard = ({ trip }: { trip: any }) => {
   const locationInfo = tripData?.find(
     (item: any) => item.locationInfo
   )?.locationInfo;
-  const startDate = tripData?.find((item: any) => item.dates)?.dates?.startDate;
-  const endDate = tripData?.find((item: any) => item.dates)?.dates?.endDate;
+  const startDateRaw = tripData?.find((item: any) => item.dates)?.dates?.startDate;
+  const endDateRaw = tripData?.find((item: any) => item.dates)?.dates?.endDate;
+  const startDate = toDate(startDateRaw);
+  const endDate = toDate(endDateRaw);
 
-  const isPastTrip = moment().isAfter(moment(endDate));
+  const isPastTrip = endDate ? moment().isAfter(moment(endDate)) : false;
 
   return (
     <View className="mt-5 flex flex-row gap-3">
       <View className="w-32 h-32">
         <Image
           source={{
-            uri: `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo?.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAP_KEY}`,
+            uri: locationInfo?.photoRef
+              ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`
+              : DEFAULT_IMAGE_URL,
           }}
           className={`w-full h-full rounded-2xl ${
             isPastTrip ? "grayscale" : ""
@@ -38,10 +59,10 @@ const UserTripCard = ({ trip }: { trip: any }) => {
           {trip?.tripPlan?.trip_plan?.location}
         </Text>
         <Text className="font-outfit text-md text-gray-500 mt-1">
-          {moment(startDate).format("DD MMM yyyy")}
+          {startDate ? moment(startDate).format("DD MMM yyyy") : ""}
         </Text>
         <Text className="font-outfit-medium text-md text-gray-500 mt-1">
-          {trip?.tripPlan?.trip_plan?.group_size.split(" ")[0]}
+          {trip?.tripPlan?.trip_plan?.group_size?.split(" ")[0] ?? "N/A"}
         </Text>
       </View>
       <View className="flex-1">

--- a/components/MyTrips/UserTripList.tsx
+++ b/components/MyTrips/UserTripList.tsx
@@ -5,6 +5,22 @@ import CustomButton from "../CustomButton";
 import UserTripCard from "./UserTripCard";
 import { useRouter } from "expo-router";
 
+const DEFAULT_IMAGE_URL =
+  "https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?q=80&w=2071&auto=format&fit=crop";
+
+const toDate = (value: any) => {
+  if (!value) return undefined;
+  if (typeof value === "string" || typeof value === "number") {
+    return new Date(value);
+  }
+  if (value.seconds) {
+    return new Date(value.seconds * 1000);
+  }
+  if (value._seconds) {
+    return new Date(value._seconds * 1000);
+  }
+  return undefined;
+};
 const UserTripList = ({ userTrips }: { userTrips: any[] }) => {
   const router = useRouter();
 
@@ -13,8 +29,12 @@ const UserTripList = ({ userTrips }: { userTrips: any[] }) => {
     const aData = JSON.parse(a.tripData);
     const bData = JSON.parse(b.tripData);
 
-    const aStartDate = aData.find((item: any) => item.dates)?.dates?.startDate;
-    const bStartDate = bData.find((item: any) => item.dates)?.dates?.startDate;
+    const aStartDate = toDate(
+      aData.find((item: any) => item.dates)?.dates?.startDate
+    );
+    const bStartDate = toDate(
+      bData.find((item: any) => item.dates)?.dates?.startDate
+    );
 
     return moment(aStartDate).valueOf() - moment(bStartDate).valueOf();
   });
@@ -25,27 +45,30 @@ const UserTripList = ({ userTrips }: { userTrips: any[] }) => {
     (item: any) => item.locationInfo
   )?.locationInfo;
 
-  const startDate = LatestTrip?.find((item: any) => item.dates)?.dates
-    ?.startDate;
-  const endDate = LatestTrip?.find((item: any) => item.dates)?.dates?.endDate;
+  const startDate = toDate(
+    LatestTrip?.find((item: any) => item.dates)?.dates?.startDate
+  );
+  const endDate = toDate(
+    LatestTrip?.find((item: any) => item.dates)?.dates?.endDate
+  );
   const travelersType = LatestTrip?.find((item: any) => item.travelers)
     ?.travelers?.type;
 
-  const isPastTrip = moment().isAfter(moment(endDate));
+  const isPastTrip = endDate ? moment().isAfter(moment(endDate)) : false;
 
   return (
     <View className="mb-16">
       <View>
-        {locationInfo?.photoRef && (
-          <Image
-            source={{
-              uri: `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo?.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAP_KEY}`,
-            }}
-            className={`w-full h-60 rounded-2xl mt-5 ${
-              isPastTrip ? "grayscale" : ""
-            }`}
-          />
-        )}
+        <Image
+          source={{
+            uri: locationInfo?.photoRef
+              ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`
+              : DEFAULT_IMAGE_URL,
+          }}
+          className={`w-full h-60 rounded-2xl mt-5 ${
+            isPastTrip ? "grayscale" : ""
+          }`}
+        />
         <View className="mt-3">
           <Text
             className={`font-outfit-medium text-xl ${
@@ -56,7 +79,7 @@ const UserTripList = ({ userTrips }: { userTrips: any[] }) => {
           </Text>
           <View className="flex flex-row justify-between items-center mt-2">
             <Text className="font-outfit text-lg text-gray-500">
-              {moment(startDate).format("DD MMM yyyy")}
+              {startDate ? moment(startDate).format("DD MMM yyyy") : ""}
             </Text>
             <Text className="font-outfit-medium mr-5 text-lg text-gray-500">
               🚌 {travelersType}

--- a/constants/Options.ts
+++ b/constants/Options.ts
@@ -50,4 +50,49 @@ export const budgetOptions = [
   },
 ];
 
-export const AI_PROMPT = "Generate a trip plan for the following data: Location - {location}. {totalDays} Day(s) and {totalNights} Night(s), for a group size of {travelers}, with a {budget} Budget. Include Flight Details, Flight Price with Booking URL, a list of hotel options with Hotel Name, Hotel Address, Price, Hotel Image URL, Geo Coordinates, Rating, Description, and Places to visit nearby with Place Name, Place Details, Place Image URL, Geo Coordinates, Ticket Price, Time to Travel to each of the location. Make sure you give this plan in JSON format.";
+export const AI_PROMPT = `Return only JSON. Generate a trip plan for Location "{location}" lasting {totalDays} day(s) and {totalNights} night(s) for {travelers} with a {budget} budget.
+
+Use this exact schema:
+{
+  "trip_plan": {
+    "location": "{location}",
+    "duration": "{totalDays} days and {totalNights} nights",
+    "group_size": "{travelers}",
+    "budget": "{budget}",
+    "flight_details": {
+      "departure_city": "",
+      "arrival_city": "",
+      "departure_date": "",
+      "departure_time": "",
+      "arrival_date": "",
+      "arrival_time": "",
+      "airline": "",
+      "flight_number": "",
+      "price": "",
+      "booking_url": ""
+    },
+    "hotel": {
+      "options": [
+        {
+          "name": "",
+          "address": "",
+          "price": "",
+          "image_url": "",
+          "geo_coordinates": { "latitude": 0, "longitude": 0 },
+          "rating": "",
+          "description": ""
+        }
+      ]
+    },
+    "places_to_visit": [
+      {
+        "name": "",
+        "details": "",
+        "image_url": "",
+        "geo_coordinates": { "latitude": 0, "longitude": 0 },
+        "ticket_price": "",
+        "time_to_travel": ""
+      }
+    ]
+  }
+}`;


### PR DESCRIPTION
## Summary
- enforce strict JSON schema for AI-generated trips so flight details, hotel options, and sightseeing entries are always included
- normalize and retry AI responses until all essential sections are present before saving a trip
- skip invalid stored trips and improve validation to prevent empty itineraries
- retry AI requests with backoff when the generative model responds with a 503 overload error
- supply sensible default flight information when the model leaves that section blank
- convert Firestore timestamps to dates and fall back to a default image when place photos are missing

## Testing
- `npm test -- --watchAll=false --runInBand --passWithNoTests`
- `npm run lint` (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_6890bb0497b08324a8ef9885069705a7