### PR TITLE
feat: switch to rapidapi for flight search

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    FIREBASE_APP_ID=your_firebase_app_id
    GOOGLE_PLACES_API_KEY=your_google_places_api_key
    EXPO_PUBLIC_BOOKING_AFFILIATE_ID=your_booking_affiliate_id
-   EXPO_PUBLIC_KIWI_API_KEY=your_kiwi_api_key
+   EXPO_PUBLIC_RAPIDAPI_KEY=your_rapidapi_key
    ```
 
    The `GOOGLE_PLACES_API_KEY` must have the Places API enabled for city and airport autocomplete.
+   The `EXPO_PUBLIC_RAPIDAPI_KEY` should be a valid key for the [Kiwi.com Cheap Flights API](https://rapidapi.com/emir12/api/kiwi-com-cheap-flights).
 
 3. Start the app
 

--- a/app/generate-trip.tsx
+++ b/app/generate-trip.tsx
@@ -25,6 +25,15 @@ const formatDate = (value: any) => {
   return "";
 };
 
+// Kiwi API expects dates as DD/MM/YYYY
+const formatDateForKiwi = (isoDate: string) => {
+  const d = new Date(isoDate);
+  const day = String(d.getDate()).padStart(2, "0");
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const year = d.getFullYear();
+  return `${day}/${month}/${year}`;
+};
+
 export default function GenerateTrip() {
   const { tripData } = useContext(CreateTripContext);
   const [error, setError] = useState<string | null>(null);
@@ -47,6 +56,7 @@ export default function GenerateTrip() {
       const originAirport = tripData.find((item) => item.originAirport)?.originAirport;
 
       const startDateStr = formatDate(dates?.startDate);
+      const kiwiDate = startDateStr ? formatDateForKiwi(startDateStr) : "";
 
       // Compute totals
       const totalDays = dates?.totalNumberOfDays || 0;
@@ -191,21 +201,32 @@ export default function GenerateTrip() {
       }
 
       if (originAirport && locationInfo?.name) {
-        const kiwiKey = process.env.EXPO_PUBLIC_KIWI_API_KEY;
-        if (kiwiKey) {
+        const rapidApiKey = process.env.EXPO_PUBLIC_RAPIDAPI_KEY;
+        const rapidHost = "kiwi-com-cheap-flights.p.rapidapi.com";
+        if (rapidApiKey) {
           try {
             const locRes = await fetch(
-              `https://api.tequila.kiwi.com/locations/query?term=${encodeURIComponent(
+              `https://${rapidHost}/locations?term=${encodeURIComponent(
                 locationInfo.name
               )}&location_types=airport&limit=1`,
-              { headers: { apikey: kiwiKey } }
+              {
+                headers: {
+                  "X-RapidAPI-Key": rapidApiKey,
+                  "X-RapidAPI-Host": rapidHost,
+                },
+              }
             );
             const locJson = await locRes.json();
             const arrival = locJson.locations?.[0];
             if (arrival?.code) {
               const flightRes = await fetch(
-                `https://api.tequila.kiwi.com/v2/search?fly_from=${originAirport.code}&fly_to=${arrival.code}&date_from=${startDateStr}&date_to=${startDateStr}&limit=1&sort=price`,
-                { headers: { apikey: kiwiKey } }
+                `https://${rapidHost}/v2/search?fly_from=${originAirport.code}&fly_to=${arrival.code}&date_from=${kiwiDate}&date_to=${kiwiDate}&limit=1&sort=price`,
+                {
+                  headers: {
+                    "X-RapidAPI-Key": rapidApiKey,
+                    "X-RapidAPI-Host": rapidHost,
+                  },
+                }
               );
               const flightJson = await flightRes.json();
               const flight = flightJson.data?.[0];
@@ -219,7 +240,8 @@ export default function GenerateTrip() {
                   departure_time: depDate.toISOString().split("T")[1].slice(0, 5),
                   arrival_date: arrDate.toISOString().split("T")[0],
                   arrival_time: arrDate.toISOString().split("T")[1].slice(0, 5),
-                  airline: flight.airlines?.[0] || "",
+                  airline:
+                    flight.airlines?.[0] || flight.route?.[0]?.airline || "",
                   flight_number:
                     flight.route?.[0]?.flight_no
                       ? `${flight.route[0].airline}${flight.route[0].flight_no}`


### PR DESCRIPTION
## Summary
- use RapidAPI's Kiwi.com Cheap Flights API instead of Tequila
- document RapidAPI key requirement
- fix flight search date formatting so airline, price, and booking link populate correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689233d791b48324837ff4ca50547616