### PR TITLE
Improve trip filtering and itinerary UX

### DIFF
--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -124,7 +124,10 @@ const Discover = () => {
     longitude: number,
     name?: string
   ) => {
-    const query = name ? encodeURIComponent(name) : `${latitude},${longitude}`;
+    const coords = `${latitude},${longitude}`;
+    const query = name
+      ? `${coords}%20(${encodeURIComponent(name)})`
+      : coords;
     const url = `https://www.google.com/maps/search/?api=1&query=${query}`;
     Linking.openURL(url);
   };
@@ -154,6 +157,12 @@ const Discover = () => {
       return [...prev, place];
     });
   };
+
+  const availableCategories = interestCategories.filter((cat) =>
+    parsedTripPlan?.trip_plan?.places_to_visit?.some((p: any) =>
+      p.categories?.includes(cat)
+    )
+  );
 
   return (
     <View className="flex-1 bg-white">
@@ -294,9 +303,11 @@ const Discover = () => {
                   className="mt-4"
                 />
                 <CustomButton
-                  title="Book Hotel"
+                  title={`Book ${hotel.name}`}
                   onPress={() =>
-                    Linking.openURL(generateBookingUrl(hotel.name))
+                    Linking.openURL(
+                      hotel.booking_url || generateBookingUrl(hotel.name)
+                    )
                   }
                   className="mt-2"
                 />
@@ -313,30 +324,34 @@ const Discover = () => {
       {/* Places to Visit */}
       <View className="mb-8">
         <Text className="text-2xl font-outfit-bold mb-4">Places to Visit</Text>
-        <Text className="font-outfit mb-2">Filter by:</Text>
-        <View className="flex-row flex-wrap mb-2">
-          {interestCategories.map((cat) => (
-            <TouchableOpacity
-              key={cat}
-              onPress={() => toggleInterest(cat)}
-              className={`px-3 py-1 m-1 rounded-full border ${
-                selectedInterests.includes(cat)
-                  ? "bg-purple-600 border-purple-600"
-                  : "border-gray-300"
-              }`}
-            >
-              <Text
-                className={`font-outfit ${
-                  selectedInterests.includes(cat)
-                    ? "text-white"
-                    : "text-gray-600"
-                }`}
-              >
-                {cat}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+        {availableCategories.length > 0 && (
+          <>
+            <Text className="font-outfit mb-2">Filter by:</Text>
+            <View className="flex-row flex-wrap mb-2">
+              {availableCategories.map((cat) => (
+                <TouchableOpacity
+                  key={cat}
+                  onPress={() => toggleInterest(cat)}
+                  className={`px-3 py-1 m-1 rounded-full border ${
+                    selectedInterests.includes(cat)
+                      ? "bg-purple-600 border-purple-600"
+                      : "border-gray-300"
+                  }`}
+                >
+                  <Text
+                    className={`font-outfit ${
+                      selectedInterests.includes(cat)
+                        ? "text-white"
+                        : "text-gray-600"
+                    }`}
+                  >
+                    {cat}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </>
+        )}
         <Text className="font-outfit text-gray-500 mb-4">
           Tap the + to add a place to your itinerary.
         </Text>

--- a/app/(tabs)/itineraries.tsx
+++ b/app/(tabs)/itineraries.tsx
@@ -81,7 +81,7 @@ const Itineraries = () => {
     return (
       <SafeAreaView className="flex-1 justify-center items-center">
         <Animated.View style={{ transform: [{ rotate: spin }] }}>
-          <Ionicons name="airplane" size={64} color="#8b5cf6" />
+          <Ionicons name="calendar" size={64} color="#8b5cf6" />
         </Animated.View>
         <Text className="font-outfit-medium mt-2">Generating itinerary...</Text>
       </SafeAreaView>
@@ -112,9 +112,15 @@ const Itineraries = () => {
         itineraries.map((it) => (
           <TouchableOpacity
             key={it.id}
-            className="p-4 mb-3 bg-gray-50 rounded-xl border border-gray-100"
+            className="p-4 mb-3 bg-gray-50 rounded-xl border border-gray-100 flex-row items-center"
             onPress={() => setCurrentId(it.id)}
           >
+            <Ionicons
+              name="calendar"
+              size={24}
+              color="#8b5cf6"
+              style={{ marginRight: 8 }}
+            />
             <Text className="font-outfit-bold">{it.title}</Text>
           </TouchableOpacity>
         ))

--- a/components/ItineraryDetails.tsx
+++ b/components/ItineraryDetails.tsx
@@ -25,11 +25,12 @@ const activityIcon = (name: string) => {
 };
 
 const linkifyText = (text: string) => {
-  const match = text.match(/\b(?:at|in|on|along)\s+([A-Z][^.,]+)/);
-  if (match) {
-    const loc = match[1].trim();
-    const before = text.slice(0, match.index! + match[0].indexOf(loc));
-    const after = text.slice(match.index! + match[0].length);
+  const parts = text.split(/\b(?:at|in|on|along)\s+/i);
+  if (parts.length > 1) {
+    const loc = parts[parts.length - 1].replace(/[.,]*$/, "").trim();
+    const idx = text.toLowerCase().lastIndexOf(loc.toLowerCase());
+    const before = text.slice(0, idx);
+    const after = text.slice(idx + loc.length);
     return (
       <Text className="text-gray-700">
         {before}
@@ -37,7 +38,7 @@ const linkifyText = (text: string) => {
           className="text-purple-600 underline"
           onPress={() =>
             Linking.openURL(
-              `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(loc)}`
+              `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(loc)}`
             )
           }
         >

--- a/components/MyTrips/UserTripCard.tsx
+++ b/components/MyTrips/UserTripCard.tsx
@@ -42,31 +42,40 @@ const UserTripCard = ({
 
   const isPastTrip = endDate ? moment().isAfter(moment(endDate)) : false;
 
+  const openTrip = () => {
+    router.push({
+      pathname: "/trip-details",
+      params: { tripData: trip.tripData, tripPlan: JSON.stringify(trip.tripPlan) },
+    });
+  };
+
   return (
-    <View className="mt-5 flex flex-row gap-3 relative">
-      <View className="w-32 h-32">
-        <Image
-          source={{
-            uri: locationInfo?.photoRef
-              ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`
-              : DEFAULT_IMAGE_URL,
-          }}
-          className={`w-full h-full rounded-2xl ${
-            isPastTrip ? "grayscale" : ""
-          }`}
-        />
+    <View className="mt-5 flex flex-row gap-3">
+      <View className="w-32 h-32 relative">
+        <TouchableOpacity onPress={openTrip} className="w-full h-full">
+          <Image
+            source={{
+              uri: locationInfo?.photoRef
+                ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`
+                : DEFAULT_IMAGE_URL,
+            }}
+            className={`w-full h-full rounded-2xl ${
+              isPastTrip ? "grayscale" : ""
+            }`}
+          />
+        </TouchableOpacity>
+        <TouchableOpacity
+          onPress={() =>
+            Alert.alert("Delete Trip", "Are you sure you want to delete this trip?", [
+              { text: "Cancel", style: "cancel" },
+              { text: "Delete", style: "destructive", onPress: () => onDelete(trip.id) },
+            ])
+          }
+          className="absolute top-0 right-0 bg-white rounded-full"
+        >
+          <Ionicons name="close" size={20} color="#ef4444" />
+        </TouchableOpacity>
       </View>
-      <TouchableOpacity
-        onPress={() =>
-          Alert.alert("Delete Trip", "Are you sure you want to delete this trip?", [
-            { text: "Cancel", style: "cancel" },
-            { text: "Delete", style: "destructive", onPress: () => onDelete(trip.id) },
-          ])
-        }
-        className="absolute top-0 right-0 bg-white rounded-full"
-      >
-        <Ionicons name="close" size={20} color="#ef4444" />
-      </TouchableOpacity>
       <View className="flex-1">
         <Text
           className={`font-outfit-medium text-lg ${
@@ -86,15 +95,7 @@ const UserTripCard = ({
       <View className="flex-1">
         <CustomButton
           title="View Trip"
-          onPress={() =>
-            router.push({
-              pathname: "/trip-details",
-              params: {
-                tripData: trip.tripData,
-                tripPlan: JSON.stringify(trip.tripPlan),
-              },
-            })
-          }
+          onPress={openTrip}
           disabled={isPastTrip}
           className={`mt-2 py-0.5 ${isPastTrip ? "opacity-50" : ""}`}
         />

--- a/components/MyTrips/UserTripList.tsx
+++ b/components/MyTrips/UserTripList.tsx
@@ -63,20 +63,32 @@ const UserTripList = ({
 
   const isPastTrip = endDate ? moment().isAfter(moment(endDate)) : false;
 
+  const openLatestTrip = () => {
+    router.push({
+      pathname: "/trip-details",
+      params: {
+        tripData: sortedTrips[0].tripData,
+        tripPlan: JSON.stringify(sortedTrips[0].tripPlan),
+      },
+    });
+  };
+
   return (
     <View className="mb-16">
       <View>
         <View className="relative">
-          <Image
-          source={{
-            uri: locationInfo?.photoRef
-              ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`
-              : DEFAULT_IMAGE_URL,
-          }}
-          className={`w-full h-60 rounded-2xl mt-5 ${
-            isPastTrip ? "grayscale" : ""
-          }`}
-        />
+          <TouchableOpacity onPress={openLatestTrip}>
+            <Image
+              source={{
+                uri: locationInfo?.photoRef
+                  ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${locationInfo.photoRef}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`
+                  : DEFAULT_IMAGE_URL,
+              }}
+              className={`w-full h-60 rounded-2xl mt-5 ${
+                isPastTrip ? "grayscale" : ""
+              }`}
+            />
+          </TouchableOpacity>
           <TouchableOpacity
             onPress={() =>
               Alert.alert("Delete Trip", "Are you sure you want to delete this trip?", [
@@ -108,15 +120,7 @@ const UserTripList = ({
 
           <CustomButton
             title="View Trip"
-            onPress={() =>
-              router.push({
-                pathname: "/trip-details",
-                params: {
-                  tripData: sortedTrips[0].tripData,
-                  tripPlan: JSON.stringify(sortedTrips[0].tripPlan),
-                },
-              })
-            }
+            onPress={openLatestTrip}
             className={`mt-3 ${isPastTrip ? "opacity-50" : ""}`}
           />
         </View>


### PR DESCRIPTION
## Summary
- hide empty interest categories and fix map links with accurate coordinates
- link itinerary text to Google Maps and support affiliate booking links
- allow opening trips from images, adjust delete icon and refresh itinerary UI

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6893244efe2883249a44a2a060ed09e4