### PR TITLE
Improve map coordinates and booking links

### DIFF
--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -392,9 +392,7 @@ const Discover = () => {
                   title="View on Map"
                   onPress={() =>
                     handleOpenMap(
-                      undefined,
-                      place.geo_coordinates.latitude,
-                      place.geo_coordinates.longitude
+                      `${place.name}, ${parsedTripPlan.trip_plan.location}`
                     )
                   }
                   className="mt-4"

--- a/app/create-trip/select-origin-airport.tsx
+++ b/app/create-trip/select-origin-airport.tsx
@@ -52,10 +52,11 @@ export default function SelectOriginAirport() {
         const rapidApiKey = process.env.EXPO_PUBLIC_RAPIDAPI_KEY;
         const rapidHost = "kiwi-com-cheap-flights.p.rapidapi.com";
         if (rapidApiKey) {
-          const res = await fetch(
-            `https://${rapidHost}/locations?term=${encodeURIComponent(
-              item.description
-            )}&location_types=airport&limit=1`,
+          const detail = await searchDetails(item.place_id);
+          const { lat, lng } = detail.geometry.location;
+          let airport;
+          let res = await fetch(
+            `https://${rapidHost}/locations?location_types=airport&limit=1&lat=${lat}&lon=${lng}`,
             {
               headers: {
                 "X-RapidAPI-Key": rapidApiKey,
@@ -63,8 +64,23 @@ export default function SelectOriginAirport() {
               },
             }
           );
-          const json = await res.json();
-          const airport = json.locations?.[0];
+          let json = await res.json();
+          airport = json.locations?.[0];
+          if (!airport) {
+            res = await fetch(
+              `https://${rapidHost}/locations?term=${encodeURIComponent(
+                item.description
+              )}&location_types=airport&limit=1`,
+              {
+                headers: {
+                  "X-RapidAPI-Key": rapidApiKey,
+                  "X-RapidAPI-Host": rapidHost,
+                },
+              }
+            );
+            json = await res.json();
+            airport = json.locations?.[0];
+          }
           if (airport) {
             name = `${airport.name} (${airport.code})`;
             code = airport.code;

--- a/components/ItineraryDetails.tsx
+++ b/components/ItineraryDetails.tsx
@@ -160,30 +160,62 @@ const ItineraryDetails: React.FC<Props> = ({ plan }) => {
                         Optional Activities
                       </Text>
                     </View>
-                    {d.optional_activities.map((act, i) => (
-                      <View
-                        key={i}
-                        className="mb-2 ml-6 flex-row items-center"
-                      >
-                        <Ionicons
-                          name={activityIcon(act.name) as any}
-                          size={20}
-                          color="#8b5cf6"
-                          style={{ marginRight: 6 }}
-                        />
-                        <View className="flex-1">{linkifyText(act.name)}</View>
-                        {act.booking_url ? (
+                    {d.optional_activities.map((act, i) => {
+                      const buildUrl = (name: string, url?: string) => {
+                        const search = (provider: "getyourguide" | "viator") =>
+                          provider === "getyourguide"
+                            ? `https://www.getyourguide.com/s/?q=${encodeURIComponent(name)}`
+                            : `https://www.viator.com/search/?q=${encodeURIComponent(name)}`;
+                        if (!url) return search("getyourguide");
+                        try {
+                          const parsed = new URL(url);
+                          if (parsed.hostname.includes("getyourguide")) {
+                            if (
+                              parsed.pathname === "/" ||
+                              parsed.pathname.split("/").filter(Boolean).length < 2
+                            ) {
+                              return search("getyourguide");
+                            }
+                            return url;
+                          }
+                          if (parsed.hostname.includes("viator")) {
+                            if (
+                              parsed.pathname === "/" ||
+                              parsed.pathname.split("/").filter(Boolean).length < 2
+                            ) {
+                              return search("viator");
+                            }
+                            return url;
+                          }
+                        } catch {
+                          // fall through to default
+                        }
+                        return search("getyourguide");
+                      };
+                      const bookingUrl = buildUrl(act.name, act.booking_url);
+                      return (
+                        <View
+                          key={i}
+                          className="mb-2 ml-6 flex-row items-center"
+                        >
+                          <Ionicons
+                            name={activityIcon(act.name) as any}
+                            size={20}
+                            color="#8b5cf6"
+                            style={{ marginRight: 6 }}
+                          />
+                          <View className="flex-1">{linkifyText(act.name)}</View>
                           <TouchableOpacity
-                            onPress={() => Linking.openURL(act.booking_url)}
+                            onPress={() => Linking.openURL(bookingUrl)}
                             className="ml-2 bg-purple-600 px-3 py-1 rounded-full"
                           >
                             <Text className="font-outfit-bold text-white text-sm">
                               Book
                             </Text>
                           </TouchableOpacity>
-                        ) : null}
-                      </View>
-                    ))}
+                        </View>
+                      );
+                    })}
                   </View>
                 ) : null}
                 {d.travel_tips ? (


### PR DESCRIPTION
## Summary
- Ensure activity booking links search GetYourGuide/Viator when URLs are generic
- Use place name & location when opening maps for visit spots
- Look up nearest airport by coordinates when city is selected

## Testing
- `npm run lint`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893352c2d1883248d71fc110ae68379