### PR TITLE
Use program-specific Travelpayouts links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    The `GOOGLE_PLACES_API_KEY` and `EXPO_PUBLIC_GOOGLE_MAPS_API_KEY` should be the same key with the Places and Maps APIs enabled for search and photos.
    The `GEMINI_API_KEY` powers AI trip generation.
 
-   The Travelpayouts marker and token enable affiliate links and API access for flights, hotels, and activities.
+   The Travelpayouts marker and token enable affiliate links and API access for flights, hotels, and activities. Affiliate links are generated with program-specific `tp.media` URLs (Aviasales for flights, Hotellook for hotels, Welcome Pickups for tours and transfers, and Searadar for cruises) to avoid 404 errors.
 
 3. Start the app
 

--- a/utils/travelpayouts.ts
+++ b/utils/travelpayouts.ts
@@ -11,7 +11,41 @@ export const generateFlightLink = (
   if (departDate) params.push(`depart_date=${departDate}`);
   if (returnDate) params.push(`return_date=${returnDate}`);
   const baseSearch = `https://www.aviasales.com/search?${params.join("&")}`;
-  return `https://www.travelpayouts.com/redirect?marker=${marker}&url=${encodeURIComponent(baseSearch)}`;
+  return `https://tp.media/r?campaign_id=100&marker=${marker}&p=4114&sub_id=ww&trs=446474&u=${encodeURIComponent(
+    baseSearch
+  )}`;
+};
+
+export interface FlightInfo {
+  airline: string;
+  flight_number: string;
+  price: string | number;
+}
+
+export const fetchFlightInfo = async (
+  origin: string,
+  destination: string,
+  departDate: string
+): Promise<FlightInfo | null> => {
+  const token = process.env.EXPO_PUBLIC_TRAVELPAYOUTS_TOKEN;
+  if (!token) return null;
+  try {
+    const res = await fetch(
+      `https://api.travelpayouts.com/aviasales/v3/prices_for_dates?origin=${origin}&destination=${destination}&departure_at=${departDate}&limit=1&token=${token}&currency=usd`
+    );
+    const json = await res.json();
+    const flight = json?.data?.[0];
+    if (flight) {
+      return {
+        airline: flight.airline || "",
+        flight_number: flight.flight_number || "",
+        price: flight.price || flight.value || "",
+      };
+    }
+  } catch (e) {
+    console.error("flight info fetch failed", e);
+  }
+  return null;
 };
 
 export const generateHotelLink = (
@@ -23,17 +57,29 @@ export const generateHotelLink = (
   const baseSearch = `https://search.hotellook.com/hotels?destination=${query}${
     checkIn ? `&checkIn=${checkIn}` : ""
   }${checkOut ? `&checkOut=${checkOut}` : ""}`;
-  return `https://www.travelpayouts.com/redirect?marker=${marker}&url=${encodeURIComponent(baseSearch)}`;
+  return `https://tp.media/r?campaign_id=101&marker=${marker}&p=4115&sub_id=ww&trs=446474&u=${encodeURIComponent(
+    baseSearch
+  )}`;
 };
 
 export const generatePoiLink = (query: string) => {
   const marker = getTravelpayoutsMarker();
-  const baseSearch = `https://www.viator.com/search-results?query=${query}`;
-  return `https://www.travelpayouts.com/redirect?marker=${marker}&url=${encodeURIComponent(baseSearch)}`;
+  const lower = query.toLowerCase();
+  if (lower.includes("cruise") || lower.includes("boat") || lower.includes("sail")) {
+    const base = "https://searadar.com";
+    return `https://tp.media/r?campaign_id=258&marker=${marker}&p=5907&sub_id=ww&trs=446474&u=${encodeURIComponent(
+      base
+    )}`;
+  }
+  const base = "https://welcomepickups.com";
+  return `https://tp.media/r?campaign_id=627&marker=${marker}&p=8919&sub_id=ww&trs=446474&u=${encodeURIComponent(
+    base
+  )}`;
 };
 
 export default {
   generateFlightLink,
+  fetchFlightInfo,
   generateHotelLink,
   generatePoiLink,
 };


### PR DESCRIPTION
## Summary
- pull flight pricing and carrier info from Travelpayouts
- fix Aviasales affiliate link with tp.media redirect
- attach program-specific booking links to hotels and activities

## Testing
- `npm run lint`
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689358f11ea88324a5a8ccf638bb1d19