### PR TITLE
Refine trip planner UI for better visibility and contrast

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -25,13 +25,13 @@ export default function Profile() {
       <Text className="text-3xl font-outfit-bold mb-8">Profile</Text>
 
       {/* User Info Section */}
-      <View className="bg-secondary p-6 rounded-xl mb-8">
+      <View className="bg-background p-6 rounded-xl mb-8 border border-primary">
         <View className="flex-row items-center mb-4">
           <View className="bg-primary p-4 rounded-full">
             <Ionicons name="person" size={32} color="#F9F5FF" />
           </View>
           <View className="ml-4">
-            <Text className="text-xl font-outfit-bold">{user?.email}</Text>
+            <Text className="text-xl font-outfit-bold text-text-primary">{user?.email}</Text>
             <Text className="text-text-primary font-outfit">
               Member since{" "}
               {user?.metadata?.creationTime

--- a/app/create-trip/review-trip.tsx
+++ b/app/create-trip/review-trip.tsx
@@ -30,7 +30,7 @@ const ReviewTrip = () => {
   ) => (
     <View className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-4 shadow-sm border border-primary">
       <View className="flex-row items-center flex-1">
-        <View className="bg-secondary p-3 rounded-full">{icon}</View>
+        <View className="bg-background p-3 rounded-full">{icon}</View>
         <View className="ml-4 flex-1">
           <Text className="text-text-primary text-sm font-outfit">{title}</Text>
           <Text className="text-lg font-outfit-bold">{value}</Text>

--- a/app/create-trip/search-place.tsx
+++ b/app/create-trip/search-place.tsx
@@ -109,11 +109,13 @@ const styles = StyleSheet.create({
   autocomplete: { flex: 1, padding: 16 },
   input: {
     height: 54,
-    backgroundColor: "#F9F5FF",
+    backgroundColor: "#FFFFFF",
     borderRadius: 999,
     paddingHorizontal: 16,
     fontSize: 15,
     marginBottom: 8,
+    borderWidth: 1,
+    borderColor: "#9C00FF",
   },
   loading: { textAlign: "center", marginVertical: 8 },
   row: {

--- a/app/create-trip/select-budget.tsx
+++ b/app/create-trip/select-budget.tsx
@@ -7,7 +7,7 @@ import {
 } from "react-native";
 import React, { useContext } from "react";
 import { budgetOptions } from "@/constants/Options";
-import { router, useRouter } from "expo-router";
+import { useRouter } from "expo-router";
 import { CreateTripContext } from "@/context/CreateTripContext";
 
 const SelectBudget = () => {
@@ -28,7 +28,7 @@ const SelectBudget = () => {
       onPress={() => handleSelectBudget(item)}
       className="flex-row items-center p-4 bg-background rounded-xl mb-4 shadow-sm border border-primary"
     >
-      <View className="bg-secondary p-3 rounded-full">
+      <View className="bg-background p-3 rounded-full">
         <Text className="text-2xl">{item.icon}</Text>
       </View>
       <View className="flex-1 ml-4">

--- a/app/create-trip/select-dates.tsx
+++ b/app/create-trip/select-dates.tsx
@@ -65,8 +65,8 @@ const SelectDates = () => {
             onDateChange={onDateChange}
             selectedDayColor="#9C00FF"
             selectedDayTextColor="#ffffff"
-            todayBackgroundColor="#22C55E"
-            todayTextStyle={{ color: "#9C00FF" }}
+            todayBackgroundColor="#B347FF"
+            todayTextStyle={{ color: "#FFFFFF" }}
             textStyle={{
               fontFamily: "outfit",
               color: "#1E1B4B",

--- a/app/create-trip/select-origin-airport.tsx
+++ b/app/create-trip/select-origin-airport.tsx
@@ -150,11 +150,13 @@ const styles = StyleSheet.create({
   autocomplete: { flex: 1, padding: 16 },
   input: {
     height: 54,
-    backgroundColor: "#F9F5FF",
+    backgroundColor: "#FFFFFF",
     borderRadius: 999,
     paddingHorizontal: 16,
     fontSize: 15,
     marginBottom: 8,
+    borderWidth: 1,
+    borderColor: "#9C00FF",
   },
   loading: { textAlign: "center", marginVertical: 8 },
   row: {

--- a/app/create-trip/select-traveler.tsx
+++ b/app/create-trip/select-traveler.tsx
@@ -33,11 +33,11 @@ const SelectTraveler = () => {
       onPress={() => handleSelectTraveler(item)}
       className="flex-row items-center p-4 bg-background rounded-xl mb-4 shadow-sm border border-primary"
     >
-      <View className="bg-secondary p-3 rounded-full">
+      <View className="bg-background p-3 rounded-full">
         {item.icon === "person" || item.icon === "people-circle" ? (
-          <Ionicons name={item.icon as any} size={24} color="#9C00FF" />
+          <Ionicons name={item.icon as any} size={24} color="#1E1B4B" />
         ) : (
-          <MaterialIcons name={item.icon as any} size={24} color="#9C00FF" />
+          <MaterialIcons name={item.icon as any} size={24} color="#1E1B4B" />
         )}
       </View>
       <View className="flex-1 ml-4">


### PR DESCRIPTION
## Summary
- highlight location and airport fields with white backgrounds and purple borders
- swap out purple icon fills for neutral backgrounds on traveler, budget, and review cards
- update calendar and profile styles for better theme consistency

## Testing
- `npm test -- --watchAll=false` (fails: No tests found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68947e0545088324ad1c482f60fc27f7