### PR TITLE
fix: handle trip generation permissions and UI

### DIFF
--- a/app/(tabs)/mytrip.tsx
+++ b/app/(tabs)/mytrip.tsx
@@ -36,7 +36,7 @@ export default function MyTrip() {
     setUserTrips([]);
     const q = query(
       collection(db, "UserTrips"),
-      where("userEmail", "==", user.email)
+      where("userId", "==", user.uid)
     );
     const querySnapshot = await getDocs(q);
 

--- a/app/generate-trip.tsx
+++ b/app/generate-trip.tsx
@@ -283,6 +283,7 @@ export default function GenerateTrip() {
       if (db && user) {
         await setDoc(doc(db, "UserTrips", docId), {
           userEmail: user.email,
+          userId: user.uid,
           tripPlan: parsed,
           tripData: JSON.stringify(tripData),
           docId,
@@ -318,10 +319,7 @@ export default function GenerateTrip() {
         </Text>
       ) : (
         <>
-          <Text className="font-outfit-bold text-3xl text-center">
-            Please Wait...
-          </Text>
-          <Text className="font-outfit-medium text-xl text-center mt-10">
+          <Text className="font-outfit-medium text-xl text-center">
             Generating your itinerary...
           </Text>
 


### PR DESCRIPTION
## Summary
- avoid Firestore permission errors by storing userId and querying trips by it
- remove unneeded "Please Wait" heading while trip is generating

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689485955c9883249a9d802d024414e5