### PR TITLE
fix trip save permissions and loading UI

### DIFF
--- a/app/(tabs)/mytrip.tsx
+++ b/app/(tabs)/mytrip.tsx
@@ -8,14 +8,7 @@ import {
 import React, { useEffect, useState } from "react";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import StartNewTripCard from "@/components/MyTrips/StartNewTripCard";
-import {
-  collection,
-  getDocs,
-  query,
-  where,
-  deleteDoc,
-  doc,
-} from "firebase/firestore";
+import { collection, getDocs, deleteDoc, doc } from "firebase/firestore";
 import { auth, db } from "@/config/FirebaseConfig";
 import UserTripList from "@/components/MyTrips/UserTripList";
 import { useRouter } from "expo-router";
@@ -34,11 +27,8 @@ export default function MyTrip() {
     if (!db || !user) return;
     setLoading(true);
     setUserTrips([]);
-    const q = query(
-      collection(db, "UserTrips"),
-      where("userEmail", "==", user.email)
-    );
-    const querySnapshot = await getDocs(q);
+    const tripCollection = collection(db, "UserTrips", user.uid, "trips");
+    const querySnapshot = await getDocs(tripCollection);
 
     querySnapshot.forEach((docSnap) => {
       const data = docSnap.data();
@@ -55,10 +45,10 @@ export default function MyTrip() {
   };
 
   const deleteTrip = async (id: string) => {
-    if (!db || !id) return;
+    if (!db || !id || !user) return;
     setLoading(true);
     try {
-      await deleteDoc(doc(db, "UserTrips", id));
+      await deleteDoc(doc(db, "UserTrips", user.uid, "trips", id));
       setUserTrips((prev) => prev.filter((trip) => trip.id !== id));
     } catch (e) {
       console.error("failed to delete trip", e);

--- a/app/generate-trip.tsx
+++ b/app/generate-trip.tsx
@@ -281,7 +281,7 @@ export default function GenerateTrip() {
       // Save the entire parsed response so downstream screens receive trip_plan
       const docId = Date.now().toString();
       if (db && user) {
-        await setDoc(doc(db, "UserTrips", docId), {
+        await setDoc(doc(db, "UserTrips", user.uid, "trips", docId), {
           userEmail: user.email,
           tripPlan: parsed,
           tripData: JSON.stringify(tripData),
@@ -319,15 +319,12 @@ export default function GenerateTrip() {
       ) : (
         <>
           <Text className="font-outfit-bold text-3xl text-center">
-            Please Wait...
-          </Text>
-          <Text className="font-outfit-medium text-xl text-center mt-10">
             Generating your itinerary...
           </Text>
 
           <Image
             source={require("@/assets/images/wishwander_loading.gif")}
-            className="w-96 h-96"
+            className="w-96 h-96 mt-10"
           />
 
           <Text className="font-outfit text-text-primary text-center mt-10">


### PR DESCRIPTION
## Summary
- save generated trips under user-specific path to satisfy Firestore security rules
- streamline loading screen text while generating trip

## Testing
- `CI=1 npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689485955c9883249a9d802d024414e5