### PR TITLE
Fix web autocomplete proxy and input focus

### DIFF
--- a/app/create-trip/search-place.tsx
+++ b/app/create-trip/search-place.tsx
@@ -11,6 +11,7 @@ import {
   Keyboard,
   SafeAreaView,
   StyleSheet,
+  Platform,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { useGoogleAutocomplete } from "@appandflow/react-native-google-autocomplete";
@@ -20,6 +21,8 @@ import { CreateTripContext } from "@/context/CreateTripContext";
 export default function SearchPlace() {
   const router = useRouter();
   const { setTripData } = useContext(CreateTripContext);
+
+  const isWeb = Platform.OS === "web";
 
   // Initialize the hook with your API key and options
   const {
@@ -35,6 +38,7 @@ export default function SearchPlace() {
       minLength: 2,
       // Allow searching for both cities and countries
       queryTypes: "geocode",
+      ...(isWeb && { proxyUrl: "https://cors.isomorphic-git.org/" }),
     }
   );
 
@@ -58,8 +62,10 @@ export default function SearchPlace() {
     router.push("/create-trip/select-origin-airport");
   };
 
+  const Wrapper: any = isWeb ? View : TouchableWithoutFeedback;
+
   return (
-    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+    <Wrapper {...(!isWeb ? { onPress: Keyboard.dismiss } : {})}>
       <SafeAreaView style={styles.container}>
         <View style={styles.header}>
           <Text style={styles.title}>Where do you want to go?</Text>
@@ -97,7 +103,7 @@ export default function SearchPlace() {
           />
         </View>
       </SafeAreaView>
-    </TouchableWithoutFeedback>
+    </Wrapper>
   );
 }
 

--- a/app/create-trip/select-origin-airport.tsx
+++ b/app/create-trip/select-origin-airport.tsx
@@ -11,6 +11,7 @@ import {
   Keyboard,
   SafeAreaView,
   StyleSheet,
+  Platform,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { useGoogleAutocomplete } from "@appandflow/react-native-google-autocomplete";
@@ -21,6 +22,7 @@ import { getNearestAirport } from "@/utils/getNearestAirport";
 export default function SelectOriginAirport() {
   const router = useRouter();
   const { setTripData } = useContext(CreateTripContext);
+  const isWeb = Platform.OS === "web";
 
   const {
     locationResults,
@@ -35,6 +37,7 @@ export default function SelectOriginAirport() {
       minLength: 2,
       // Restrict results to airport establishments only
       queryTypes: "establishment",
+      ...(isWeb && { proxyUrl: "https://cors.isomorphic-git.org/" }),
     }
   );
 
@@ -99,8 +102,10 @@ export default function SelectOriginAirport() {
     router.push("/create-trip/select-traveler");
   };
 
+  const Wrapper: any = isWeb ? View : TouchableWithoutFeedback;
+
   return (
-    <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+    <Wrapper {...(!isWeb ? { onPress: Keyboard.dismiss } : {})}>
       <SafeAreaView style={styles.container}>
         <View style={styles.header}>
           <Text style={styles.title}>Which airport are you flying from?</Text>
@@ -138,7 +143,7 @@ export default function SelectOriginAirport() {
           />
         </View>
       </SafeAreaView>
-    </TouchableWithoutFeedback>
+    </Wrapper>
   );
 }
 


### PR DESCRIPTION
## Summary
- handle Google Places autocomplete on web by adding proxy URL
- avoid input focus loss on web by using platform-specific wrapper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68949e9a9f5c83249231895915ac7514