### PR TITLE
feat: add chat agent planning and background monitoring

### DIFF
--- a/config/GeminiConfig.ts
+++ b/config/GeminiConfig.ts
@@ -38,3 +38,27 @@ export function startChatSession(
     history,
   });
 }
+
+/**
+ * createFunctionCallModel
+ * Utility for agents that leverage the model's tool/function calling
+ * capabilities. Provide an array of function declarations describing
+ * the functions the model may invoke. The returned GenerativeModel can
+ * then be used to start chat sessions that respond with functionCalls
+ * when appropriate.
+ */
+export function createFunctionCallModel(
+  functionDeclarations: any[],
+  modelName: string = 'gemini-1.5-flash'
+) {
+  return genAI.getGenerativeModel({
+    model: modelName,
+    tools: [
+      {
+        functionDeclarations,
+      },
+    ],
+  });
+}
+
+export { defaultGenerationConfig };

--- a/services/backgroundMonitor.ts
+++ b/services/backgroundMonitor.ts
@@ -1,0 +1,64 @@
+import * as TaskManager from 'expo-task-manager';
+import * as BackgroundFetch from 'expo-background-fetch';
+import * as Notifications from 'expo-notifications';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '@/config/FirebaseConfig';
+import { Itinerary } from '@/types/itinerary';
+
+const TASK_NAME = 'background-trip-monitor';
+
+TaskManager.defineTask(TASK_NAME, async () => {
+  try {
+    await checkTrips();
+    return BackgroundFetch.BackgroundFetchResult.NewData;
+  } catch (e) {
+    console.error('Trip monitor failed', e);
+    return BackgroundFetch.BackgroundFetchResult.Failed;
+  }
+});
+
+export async function registerTripMonitor() {
+  await BackgroundFetch.registerTaskAsync(TASK_NAME, {
+    minimumInterval: 60 * 30, // every 30 minutes
+    stopOnTerminate: false,
+    startOnBoot: true,
+  });
+}
+
+export async function unregisterTripMonitor() {
+  await BackgroundFetch.unregisterTaskAsync(TASK_NAME);
+}
+
+async function checkTrips() {
+  if (!db) return;
+  const snap = await getDocs(collection(db, 'Itineraries'));
+  for (const docSnap of snap.docs) {
+    const trip = docSnap.data() as Itinerary;
+    const alert = await checkWeather(trip.destination);
+    if (alert) {
+      await Notifications.scheduleNotificationAsync({
+        content: {
+          title: `Update for ${trip.destination}`,
+          body: alert,
+        },
+        trigger: null,
+      });
+    }
+  }
+}
+
+async function checkWeather(city: string): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `https://wttr.in/${encodeURIComponent(city)}?format=j1`
+    );
+    const json = await res.json();
+    const condition = json?.current_condition?.[0]?.weatherDesc?.[0]?.value;
+    if (condition && /storm|rain|snow/i.test(condition)) {
+      return `Weather alert: ${condition}`;
+    }
+  } catch (e) {
+    console.error('Weather check failed', e);
+  }
+  return null;
+}

--- a/services/chatAgent.ts
+++ b/services/chatAgent.ts
@@ -1,0 +1,95 @@
+import { createFunctionCallModel, defaultGenerationConfig } from '@/config/GeminiConfig';
+import {
+  fetchCheapestFlights,
+  generateHotelLink,
+  generatePoiLink,
+} from '@/utils/travelpayouts';
+import { Booking } from '@/types/itinerary';
+
+// Function declarations exposed to the model for function calling
+const functionDeclarations = [
+  {
+    name: 'searchFlights',
+    description: 'Retrieve cheapest flight options',
+    parameters: {
+      type: 'object',
+      properties: {
+        origin: { type: 'string' },
+        destination: { type: 'string' },
+        departDate: { type: 'string', description: 'YYYY-MM-DD' },
+      },
+      required: ['origin', 'destination', 'departDate'],
+    },
+  },
+  {
+    name: 'searchHotels',
+    description: 'Generate a hotel booking link for a destination',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        checkIn: { type: 'string', description: 'YYYY-MM-DD' },
+        checkOut: { type: 'string', description: 'YYYY-MM-DD' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'searchActivities',
+    description: 'Generate a booking link for local activities or transfers',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+      },
+      required: ['query'],
+    },
+  },
+];
+
+const model = createFunctionCallModel(functionDeclarations);
+
+/**
+ * runAgent
+ * Basic chat agent that supports function calling. The model may issue
+ * functionCalls in its response which are executed locally and fed back
+ * to the chat session.
+ */
+export async function runAgent(prompt: string): Promise<string> {
+  const chat = model.startChat({ generationConfig: defaultGenerationConfig });
+  let result = await chat.sendMessage(prompt);
+
+  // Loop through function calls until the model returns final text
+  while (result.response.functionCalls && result.response.functionCalls.length) {
+    for (const call of result.response.functionCalls) {
+      const args = call.args ? JSON.parse(call.args) : {};
+      let response: any = {};
+      if (call.name === 'searchFlights') {
+        const flights = await fetchCheapestFlights(
+          args.origin,
+          args.destination,
+          args.departDate
+        );
+        response = flights.slice(0, 3);
+      } else if (call.name === 'searchHotels') {
+        const url = generateHotelLink(args.query, args.checkIn, args.checkOut);
+        response = { booking_url: url } as Booking;
+      } else if (call.name === 'searchActivities') {
+        const url = generatePoiLink(args.query);
+        response = { booking_url: url } as Booking;
+      }
+      result = await chat.sendMessage([
+        {
+          functionResponse: {
+            name: call.name,
+            response,
+          },
+        },
+      ]);
+    }
+  }
+
+  return result.response.text();
+}
+
+export { functionDeclarations };

--- a/services/planTrip.ts
+++ b/services/planTrip.ts
@@ -1,0 +1,38 @@
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db } from '@/config/FirebaseConfig';
+import { runAgent } from './chatAgent';
+import { Itinerary } from '@/types/itinerary';
+
+/**
+ * planTrip
+ * Runs the chat agent with a user prompt and stores the resulting itinerary
+ * in Firestore. Returns the persisted itinerary object.
+ */
+export async function planTrip(prompt: string): Promise<Itinerary | null> {
+  const text = await runAgent(prompt);
+  let itinerary: Itinerary;
+  try {
+    itinerary = JSON.parse(text);
+  } catch (e) {
+    console.error('Failed to parse itinerary', e);
+    return null;
+  }
+  const id = Date.now().toString();
+  const data: Itinerary = {
+    id,
+    destination: itinerary.destination,
+    prompt,
+    createdAt: Date.now(),
+    flights: itinerary.flights || [],
+    hotels: itinerary.hotels || [],
+    activities: itinerary.activities || [],
+    metadata: itinerary.metadata || {},
+  };
+  if (db && auth.currentUser) {
+    await setDoc(doc(db, 'Itineraries', id), {
+      userId: auth.currentUser.uid,
+      ...data,
+    });
+  }
+  return data;
+}

--- a/types/itinerary.ts
+++ b/types/itinerary.ts
@@ -1,0 +1,16 @@
+export interface Booking {
+  type: 'flight' | 'hotel' | 'activity';
+  name: string;
+  booking_url: string;
+}
+
+export interface Itinerary {
+  id: string;
+  destination: string;
+  prompt: string;
+  createdAt: number;
+  flights: Booking[];
+  hotels: Booking[];
+  activities: Booking[];
+  metadata?: Record<string, any>;
+}


### PR DESCRIPTION
## Summary
- add support for Gemini function calling to enable flight, hotel, and activity lookups
- persist structured itineraries via new planning service
- add background trip monitor that polls for weather issues and sends notifications

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894d56903bc83248d4f421426027d13