### PR TITLE
Enhance affiliate links and tracking

### DIFF
--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -18,6 +18,7 @@ import {
   fetchCheapestFlights,
 } from "@/utils/travelpayouts";
 import { fetchFlightEmissions } from "@/utils/emissions";
+import { recordAffiliateClick } from "@/services/affiliate";
 
 const DEFAULT_IMAGE_URL =
   "https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?q=80&w=2071&auto=format&fit=crop";
@@ -151,6 +152,11 @@ const Discover = () => {
   const hotelOptions =
     parsedTripPlan?.trip_plan?.hotel?.options
       ?.filter((h: any) => h.booking_url?.startsWith("http"))
+      .sort(
+        (a: any, b: any) =>
+          parseFloat(String(a.price).replace(/[^0-9.]/g, "")) -
+          parseFloat(String(b.price).replace(/[^0-9.]/g, ""))
+      )
       .slice(0, 10) || [];
   const ITEM_WIDTH = 304;
   const scrollHotels = (dir: number) => {
@@ -343,11 +349,12 @@ const Discover = () => {
               ) && (
                 <CustomButton
                   title="Book Flight"
-                  onPress={() =>
+                  onPress={() => {
+                    recordAffiliateClick("flight");
                     Linking.openURL(
                       parsedTripPlan.trip_plan.flight_details.booking_url
-                    )
-                  }
+                    );
+                  }}
                   className="mt-4"
                 />
               )}
@@ -376,6 +383,13 @@ const Discover = () => {
                   />
                   {sortedFlightOptions.map((f, i) => (
                     <View key={i} className="mt-4">
+                      {i === 0 && (
+                        <View className="self-start mb-1 bg-secondary/30 px-2 py-1 rounded-full">
+                          <Text className="text-xs font-outfit-bold text-primary">
+                            {sortByEmission ? "Eco friendly" : "Best deal"}
+                          </Text>
+                        </View>
+                      )}
                       <Text className="font-outfit text-text-primary">
                         {`${f.airline} ${f.flight_number} - $${f.price}`}
                       </Text>
@@ -386,7 +400,10 @@ const Discover = () => {
                       )}
                       <CustomButton
                         title="Book"
-                        onPress={() => Linking.openURL(f.booking_url)}
+                        onPress={() => {
+                          recordAffiliateClick("flight");
+                          Linking.openURL(f.booking_url);
+                        }}
                         className="mt-2"
                       />
                     </View>
@@ -397,10 +414,12 @@ const Discover = () => {
                       const { origin, destination } = getFlightCodes();
                       const depart =
                         parsedTripPlan.trip_plan.flight_details.departure_date;
-                      if (origin && destination && depart)
+                      if (origin && destination && depart) {
+                        recordAffiliateClick("flight");
                         Linking.openURL(
                           generateFlightLink(origin, destination, depart)
                         );
+                      }
                     }}
                     bgVariant="outline"
                     textVariant="primary"
@@ -440,8 +459,13 @@ const Discover = () => {
                 data={hotelOptions}
                 horizontal
                 keyExtractor={(_, i) => i.toString()}
-                renderItem={({ item }) => (
+                renderItem={({ item, index }) => (
                   <View className="w-72 mr-4 bg-background p-4 rounded-xl border border-primary">
+                    {index === 0 && (
+                      <View className="self-start mb-2 bg-secondary/30 px-2 py-1 rounded-full">
+                        <Text className="text-xs font-outfit-bold text-primary">Best deal</Text>
+                      </View>
+                    )}
                     <Image
                       source={{ uri: item.image_url || DEFAULT_IMAGE_URL }}
                       className="w-full h-48 rounded-xl mb-4"
@@ -475,7 +499,10 @@ const Discover = () => {
                     {item.booking_url?.startsWith("http") && (
                       <CustomButton
                         title="Book Hotel"
-                        onPress={() => Linking.openURL(item.booking_url)}
+                        onPress={() => {
+                          recordAffiliateClick("hotel");
+                          Linking.openURL(item.booking_url);
+                        }}
                         className="mt-2"
                       />
                     )}
@@ -495,11 +522,12 @@ const Discover = () => {
             </View>
             <CustomButton
               title="See More Hotels"
-              onPress={() =>
+              onPress={() => {
+                recordAffiliateClick("hotel");
                 Linking.openURL(
                   generateHotelLink(parsedTripPlan.trip_plan.location)
-                )
-              }
+                );
+              }}
               bgVariant="outline"
               textVariant="primary"
               className="mt-4"
@@ -604,7 +632,10 @@ const Discover = () => {
                 {place.booking_url?.startsWith("http") && (
                   <CustomButton
                     title="Book Tickets"
-                    onPress={() => Linking.openURL(place.booking_url)}
+                    onPress={() => {
+                      recordAffiliateClick("poi");
+                      Linking.openURL(place.booking_url);
+                    }}
                     className="mt-2"
                   />
                 )}

--- a/components/ItineraryDetails.tsx
+++ b/components/ItineraryDetails.tsx
@@ -5,6 +5,7 @@ import moment from "moment";
 import CustomButton from "@/components/CustomButton";
 import { DayPlan } from "@/context/ItineraryContext";
 import { generateHotelLink } from "@/utils/travelpayouts";
+import { recordAffiliateClick } from "@/services/affiliate";
 
 interface Props {
   plan: DayPlan[];
@@ -134,9 +135,10 @@ const ItineraryDetails: React.FC<Props> = ({ plan }) => {
                       {linkifyText(d.stay_options)}
                       <TouchableOpacity
                         className="mt-2 bg-primary px-3 py-1 rounded-full w-24 items-center"
-                        onPress={() =>
-                          Linking.openURL(generateStayLink(d.stay_options))
-                        }
+                        onPress={() => {
+                          recordAffiliateClick("hotel");
+                          Linking.openURL(generateStayLink(d.stay_options));
+                        }}
                       >
                         <Text className="font-outfit-bold text-white">Book</Text>
                       </TouchableOpacity>
@@ -181,7 +183,10 @@ const ItineraryDetails: React.FC<Props> = ({ plan }) => {
                         </TouchableOpacity>
                         {act.booking_url?.startsWith("http") && (
                           <TouchableOpacity
-                            onPress={() => Linking.openURL(act.booking_url)}
+                            onPress={() => {
+                              recordAffiliateClick("poi");
+                              Linking.openURL(act.booking_url);
+                            }}
                             className="ml-2 bg-primary px-3 py-1 rounded-full"
                           >
                             <Text className="font-outfit-bold text-white text-sm">

--- a/services/affiliate.ts
+++ b/services/affiliate.ts
@@ -1,0 +1,26 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const KEY = "affiliate_click_counts";
+
+export type AffiliateType = "flight" | "hotel" | "poi";
+
+export const recordAffiliateClick = async (type: AffiliateType) => {
+  try {
+    const existing = await AsyncStorage.getItem(KEY);
+    const data = existing ? JSON.parse(existing) : {};
+    data[type] = (data[type] || 0) + 1;
+    await AsyncStorage.setItem(KEY, JSON.stringify(data));
+  } catch (e) {
+    console.error("failed to record affiliate click", e);
+  }
+};
+
+export const getAffiliateClicks = async (): Promise<Record<string, number>> => {
+  try {
+    const existing = await AsyncStorage.getItem(KEY);
+    return existing ? JSON.parse(existing) : {};
+  } catch (e) {
+    console.error("failed to load affiliate clicks", e);
+    return {};
+  }
+};

--- a/utils/travelpayouts.test.ts
+++ b/utils/travelpayouts.test.ts
@@ -1,0 +1,42 @@
+import { generateFlightLink, generateHotelLink, generatePoiLink } from "./travelpayouts";
+
+describe("travelpayouts link generators", () => {
+  beforeEach(() => {
+    process.env.EXPO_PUBLIC_TRAVELPAYOUTS_MARKER = "test";
+  });
+
+  it("generates flight link with params", () => {
+    const url = generateFlightLink("NYC", "LON", "2025-12-01", "2025-12-10");
+    const tp = new URL(url);
+    expect(tp.hostname).toBe("tp.media");
+    const marker = tp.searchParams.get("marker");
+    expect(marker).toBe("test");
+    const redirect = new URL(decodeURIComponent(tp.searchParams.get("u")!));
+    expect(redirect.searchParams.get("origin")).toBe("NYC");
+    expect(redirect.searchParams.get("destination")).toBe("LON");
+    expect(redirect.searchParams.get("depart_date")).toBe("2025-12-01");
+    expect(redirect.searchParams.get("return_date")).toBe("2025-12-10");
+  });
+
+  it("generates hotel link with params", () => {
+    const url = generateHotelLink("New York", "2025-12-01", "2025-12-05");
+    const tp = new URL(url);
+    expect(tp.hostname).toBe("tp.media");
+    const redirect = new URL(decodeURIComponent(tp.searchParams.get("u")!));
+    expect(redirect.searchParams.get("destination")).toBe("New York");
+    expect(redirect.searchParams.get("checkIn")).toBe("2025-12-01");
+    expect(redirect.searchParams.get("checkOut")).toBe("2025-12-05");
+  });
+
+  it("generates poi link with query", () => {
+    const cruise = generatePoiLink("Boat cruise");
+    const tp = new URL(cruise);
+    const redirect = new URL(decodeURIComponent(tp.searchParams.get("u")!));
+    expect(redirect.href).toContain("searadar.com/search?q=Boat%20cruise");
+
+    const tour = generatePoiLink("Lisbon tour");
+    const tp2 = new URL(tour);
+    const redirect2 = new URL(decodeURIComponent(tp2.searchParams.get("u")!));
+    expect(redirect2.href).toContain("welcomepickups.com/search?q=Lisbon%20tour");
+  });
+});

--- a/utils/travelpayouts.ts
+++ b/utils/travelpayouts.ts
@@ -88,9 +88,11 @@ export const generateHotelLink = (
   checkOut?: string
 ) => {
   const marker = getTravelpayoutsMarker();
-  const baseSearch = `https://search.hotellook.com/hotels?destination=${query}${
-    checkIn ? `&checkIn=${checkIn}` : ""
-  }${checkOut ? `&checkOut=${checkOut}` : ""}`;
+  const baseSearch = `https://search.hotellook.com/hotels?destination=${encodeURIComponent(
+    query
+  )}${checkIn ? `&checkIn=${checkIn}` : ""}${
+    checkOut ? `&checkOut=${checkOut}` : ""
+  }`;
   return `https://tp.media/r?campaign_id=101&marker=${marker}&p=4115&sub_id=ww&trs=446474&u=${encodeURIComponent(
     baseSearch
   )}`;
@@ -100,12 +102,12 @@ export const generatePoiLink = (query: string) => {
   const marker = getTravelpayoutsMarker();
   const lower = query.toLowerCase();
   if (lower.includes("cruise") || lower.includes("boat") || lower.includes("sail")) {
-    const base = "https://searadar.com";
+    const base = `https://searadar.com/search?q=${encodeURIComponent(query)}`;
     return `https://tp.media/r?campaign_id=258&marker=${marker}&p=5907&sub_id=ww&trs=446474&u=${encodeURIComponent(
       base
     )}`;
   }
-  const base = "https://welcomepickups.com";
+  const base = `https://welcomepickups.com/search?q=${encodeURIComponent(query)}`;
   return `https://tp.media/r?campaign_id=627&marker=${marker}&p=8919&sub_id=ww&trs=446474&u=${encodeURIComponent(
     base
   )}`;


### PR DESCRIPTION
## Summary
- Encode search params and queries in Travelpayouts affiliate links
- Sort flight and hotel options, tagging the top result as best or eco-friendly
- Track affiliate link clicks locally for analytics

## Testing
- `CI=true npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68951892f3208324b637ec4480c2f5c7