### PR TITLE
feat: add premium subscription framework

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -18,5 +18,6 @@ export default ({ config }) => ({
     facebookAppId: process.env.FACEBOOK_APP_ID,
     sendgridApiKey: process.env.SENDGRID_API_KEY,
     sendgridFromEmail: process.env.SENDGRID_FROM_EMAIL,
+    stripePublishableKey: process.env.STRIPE_PUBLISHABLE_KEY,
   },
 });

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -6,10 +6,13 @@ import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import CustomButton from "@/components/CustomButton";
 import { UserPreferencesContext } from "@/context/UserPreferencesContext";
+import { SubscriptionContext } from "@/context/SubscriptionContext";
+import { subscribeUser } from "@/services/payment";
 
 export default function Profile() {
   const user = auth?.currentUser;
   const { preferences, setPreferences } = useContext(UserPreferencesContext);
+  const { subscription } = useContext(SubscriptionContext);
   const [form, setForm] = useState({
     budget: preferences.budget ? String(preferences.budget) : "",
     preferredAirlines: preferences.preferredAirlines.join(", "),
@@ -74,6 +77,19 @@ export default function Profile() {
               : ""}
           </Text>
         </TouchableOpacity>
+      </View>
+
+      {/* Subscription Section */}
+      <View className="mb-8">
+        <Text className="text-xl font-outfit-bold mb-4">Subscription</Text>
+        <Text className="text-text-primary font-outfit mb-4">
+          {subscription.isPremium
+            ? "You are a premium member."
+            : "You are using the free plan."}
+        </Text>
+        {!subscription.isPremium && (
+          <CustomButton title="Upgrade to Premium" onPress={subscribeUser} />
+        )}
       </View>
 
       {/* Preferences Section */}

--- a/context/SubscriptionContext.ts
+++ b/context/SubscriptionContext.ts
@@ -1,0 +1,12 @@
+import { createContext } from "react";
+import { SubscriptionState, defaultSubscriptionState } from "@/types/subscription";
+
+interface SubscriptionContextType {
+  subscription: SubscriptionState;
+  setSubscription: React.Dispatch<React.SetStateAction<SubscriptionState>>;
+}
+
+export const SubscriptionContext = createContext<SubscriptionContextType>({
+  subscription: defaultSubscriptionState,
+  setSubscription: () => {},
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.1.6",
         "@react-navigation/stack": "^7.4.5",
         "@sendgrid/mail": "^8.1.5",
+        "@stripe/stripe-react-native": "^0.38.6",
         "date-fns": "^4.1.0",
         "expo": "~53.0.20",
         "expo-auth-session": "~6.2.1",
@@ -4287,6 +4288,22 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-react-native": {
+      "version": "0.38.6",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-react-native/-/stripe-react-native-0.38.6.tgz",
+      "integrity": "sha512-U6yELoRr4h4x+p9an0MiDXZBbm/FYNayPXJP0PtsR3iFVAGpGQm6DzM+cye2PVlhbDK8htBA5ReZ1YEFxT/hJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": ">=46.0.9",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.4.5",
     "@sendgrid/mail": "^8.1.5",
+    "@stripe/stripe-react-native": "^0.38.6",
     "date-fns": "^4.1.0",
     "expo": "~53.0.20",
     "expo-auth-session": "~6.2.1",

--- a/services/payment.ts
+++ b/services/payment.ts
@@ -1,0 +1,34 @@
+import { initStripe } from "@stripe/stripe-react-native";
+import Constants from "expo-constants";
+
+const STRIPE_KEY =
+  Constants.expoConfig?.extra?.stripePublishableKey ||
+  process.env.STRIPE_PUBLISHABLE_KEY ||
+  "";
+
+/**
+ * Initialize Stripe with the publishable key. Should be called once on app start.
+ */
+export const initializeStripe = async (): Promise<void> => {
+  if (!STRIPE_KEY) {
+    console.warn("Stripe publishable key is missing");
+    return;
+  }
+  await initStripe({ publishableKey: STRIPE_KEY });
+};
+
+/**
+ * Placeholder to trigger a subscription purchase flow.
+ * In a real implementation this would call your backend to create a checkout session
+ * or payment sheet and then present it to the user.
+ */
+export const subscribeUser = async (): Promise<void> => {
+  console.log("Launching subscription flow...");
+};
+
+/**
+ * Placeholder to query backend for current subscription status.
+ */
+export const checkSubscriptionStatus = async (): Promise<boolean> => {
+  return false;
+};

--- a/services/subscription.ts
+++ b/services/subscription.ts
@@ -1,0 +1,33 @@
+import { auth, db } from "@/config/FirebaseConfig";
+import { doc, getDoc } from "firebase/firestore";
+import { SubscriptionState, defaultSubscriptionState } from "@/types/subscription";
+
+/**
+ * Fetch subscription state for the current user from Firestore.
+ * Falls back to a default non-premium state when unavailable.
+ */
+export const fetchSubscriptionState = async (): Promise<SubscriptionState> => {
+  if (!auth.currentUser) return defaultSubscriptionState;
+  try {
+    const ref = doc(db, "users", auth.currentUser.uid);
+    const snap = await getDoc(ref);
+    if (!snap.exists()) return defaultSubscriptionState;
+    const data = snap.data();
+    return {
+      isPremium: Boolean(data.isPremium),
+      entitlements: Array.isArray(data.entitlements) ? data.entitlements : [],
+      status: data.subscriptionStatus || "inactive",
+    };
+  } catch (e) {
+    console.warn("fetchSubscriptionState failed", e);
+    return defaultSubscriptionState;
+  }
+};
+
+/**
+ * Convenience helper to determine if a given entitlement is present.
+ */
+export const hasEntitlement = (
+  state: SubscriptionState,
+  entitlement: string
+): boolean => state.entitlements.includes(entitlement);

--- a/types/subscription.ts
+++ b/types/subscription.ts
@@ -1,0 +1,11 @@
+export interface SubscriptionState {
+  isPremium: boolean;
+  entitlements: string[];
+  status: "active" | "inactive" | "canceled";
+}
+
+export const defaultSubscriptionState: SubscriptionState = {
+  isPremium: false,
+  entitlements: [],
+  status: "inactive",
+};


### PR DESCRIPTION
## Summary
- scaffold subscription state with context and Firebase-backed flag
- add Stripe integration placeholder with upgrade button
- expose Stripe publishable key via app config

## Testing
- `npm test -- --watchAll=false`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895bff9c3c48324949e9c24a9393eea