### PR TITLE
fix: avoid __extends error by lazy loading services

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,14 +24,11 @@ import {
 import { UserPreferencesContext } from "@/context/UserPreferencesContext";
 import { UserPreferences } from "@/types/user";
 import HeaderLogo from "@/components/HeaderLogo";
-import { registerTripMonitor } from "@/services/tripMonitor";
-import { initializeStripe } from "@/services/payment";
 import { SubscriptionContext } from "@/context/SubscriptionContext";
 import {
   SubscriptionState,
   defaultSubscriptionState,
 } from "@/types/subscription";
-import { fetchSubscriptionState } from "@/services/subscription";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
@@ -91,6 +88,9 @@ export default function RootLayout() {
         if (stored) {
           setSubscription(JSON.parse(stored));
         } else {
+          const { fetchSubscriptionState } = await import(
+            "@/services/subscription"
+          );
           const remote = await fetchSubscriptionState();
           setSubscription(remote);
         }
@@ -135,8 +135,12 @@ export default function RootLayout() {
   useEffect(() => {
     if (loaded) {
       SplashScreen.hideAsync();
-      registerTripMonitor();
-      initializeStripe();
+      import("@/services/tripMonitor").then(({ registerTripMonitor }) =>
+        registerTripMonitor()
+      );
+      import("@/services/payment").then(({ initializeStripe }) =>
+        initializeStripe()
+      );
     }
   }, [loaded]);
 


### PR DESCRIPTION
## Summary
- lazily fetch subscription state to avoid static Firebase import
- dynamically load background tasks and Stripe init after fonts load

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d9917c108324801736d3edd5572b