### PR TITLE
fix: resolve runtime errors and lint warnings

### DIFF
--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,8 +1,3 @@
-import {
-  DarkTheme,
-  DefaultTheme,
-  ThemeProvider,
-} from "@react-navigation/native";
 import { Stack } from "expo-router";
 
 export default function AuthLayout() {

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -13,7 +13,7 @@ export default function SignIn() {
     email: "",
     password: "",
   });
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading] = useState(false);
 
   const onLoginPress = async () => {
     try {

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -14,7 +14,7 @@ export default function SignUp() {
     email: "",
     password: "",
   });
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading] = useState(false);
 
   const onSignUpPress = async () => {
     try {

--- a/app/(auth)/welcome.tsx
+++ b/app/(auth)/welcome.tsx
@@ -1,4 +1,4 @@
-import { View, Text, TouchableOpacity, Image } from "react-native";
+import { View, Text, TouchableOpacity } from "react-native";
 import React, { useRef, useState } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { router } from "expo-router";

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -37,6 +37,7 @@ const ChatScreen = () => {
       const text = await result.response.text();
       setMessages((prev) => [...prev, { role: 'model', text }]);
     } catch (e) {
+      console.error(e);
       setMessages((prev) => [...prev, { role: 'model', text: 'Something went wrong.' }]);
     }
   };

--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -7,7 +7,13 @@ import {
   TouchableOpacity,
   FlatList,
 } from "react-native";
-import React, { useEffect, useState, useRef, useContext } from "react";
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  useContext,
+  useCallback,
+} from "react";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import CustomButton from "@/components/CustomButton";
@@ -118,7 +124,26 @@ const Discover = () => {
     }
   }, [tripData, tripPlan]);
 
-  const loadFlightEmission = async () => {
+  const getFlightCodes = useCallback(() => {
+    const origin = parsedTripData?.find((i: any) => i.originAirport)?.originAirport?.code;
+    const booking = parsedTripPlan?.trip_plan?.flight_details?.booking_url;
+    if (booking) {
+      try {
+        const tp = new URL(booking);
+        const search = tp.searchParams.get("u");
+        if (search) {
+          const decoded = new URL(decodeURIComponent(search));
+          return {
+            origin: decoded.searchParams.get("origin") || origin,
+            destination: decoded.searchParams.get("destination") || undefined,
+          };
+        }
+      } catch {}
+    }
+    return { origin, destination: undefined };
+  }, [parsedTripData, parsedTripPlan]);
+
+  const loadFlightEmission = useCallback(async () => {
     const { origin, destination } = getFlightCodes();
     if (!origin || !destination) return;
     const airline = parsedTripPlan?.trip_plan?.flight_details?.airline;
@@ -130,13 +155,13 @@ const Discover = () => {
       flightNumber
     );
     if (grams != null) setFlightEmissionKg(grams / 1000);
-  };
+  }, [getFlightCodes, parsedTripPlan]);
 
   useEffect(() => {
     if (parsedTripPlan?.trip_plan?.flight_details) {
       loadFlightEmission();
     }
-  }, [parsedTripPlan]);
+  }, [parsedTripPlan, loadFlightEmission]);
 
   const filteredPlaces =
     parsedTripPlan?.trip_plan?.places_to_visit?.filter((p: any) =>
@@ -216,25 +241,6 @@ const Discover = () => {
         ? prev.filter((i) => i !== interest)
         : [...prev, interest]
     );
-  };
-
-  const getFlightCodes = () => {
-    const origin = parsedTripData?.find((i: any) => i.originAirport)?.originAirport?.code;
-    const booking = parsedTripPlan?.trip_plan?.flight_details?.booking_url;
-    if (booking) {
-      try {
-        const tp = new URL(booking);
-        const search = tp.searchParams.get("u");
-        if (search) {
-          const decoded = new URL(decodeURIComponent(search));
-          return {
-            origin: decoded.searchParams.get("origin") || origin,
-            destination: decoded.searchParams.get("destination") || undefined,
-          };
-        }
-      } catch {}
-    }
-    return { origin, destination: undefined };
   };
 
   const loadCheapestFlights = async () => {

--- a/app/(tabs)/mytrip.tsx
+++ b/app/(tabs)/mytrip.tsx
@@ -5,7 +5,7 @@ import {
   TouchableOpacity,
   ScrollView,
 } from "react-native";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import StartNewTripCard from "@/components/MyTrips/StartNewTripCard";
 import { collection, getDocs, deleteDoc, doc } from "firebase/firestore";
@@ -19,11 +19,7 @@ export default function MyTrip() {
   const [loading, setLoading] = useState(false);
   const router = useRouter();
 
-  useEffect(() => {
-    user && getMyTrips();
-  }, [user]);
-
-  const getMyTrips = async () => {
+  const getMyTrips = useCallback(async () => {
     if (!db || !user) return;
     setLoading(true);
     setUserTrips([]);
@@ -42,7 +38,11 @@ export default function MyTrip() {
       }
     });
     setLoading(false);
-  };
+  }, [user]);
+
+  useEffect(() => {
+    if (user) getMyTrips();
+  }, [user, getMyTrips]);
 
   const deleteTrip = async (id: string) => {
     if (!db || !id || !user) return;
@@ -68,7 +68,7 @@ export default function MyTrip() {
         </TouchableOpacity>
       </View>
       {loading && <ActivityIndicator size="large" color="#9C00FF" />}
-      {userTrips?.length == 0 ? (
+      {userTrips.length === 0 ? (
         <StartNewTripCard />
       ) : (
         <UserTripList userTrips={userTrips} onDelete={deleteTrip} />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,26 +1,16 @@
 import "setimmediate";
 import "@/config/sentry";
-import {
-  DarkTheme,
-  DefaultTheme,
-  ThemeProvider,
-} from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect, useState } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import "react-native-reanimated";
-import { useColorScheme } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import "../global.css";
 import "react-native-get-random-values";
 import { CreateTripContext } from "@/context/CreateTripContext";
-import {
-  ItineraryContext,
-  DayPlan,
-  StoredItinerary,
-} from "@/context/ItineraryContext";
+import { ItineraryContext, StoredItinerary } from "@/context/ItineraryContext";
 import { UserPreferencesContext } from "@/context/UserPreferencesContext";
 import { UserPreferences } from "@/types/user";
 import HeaderLogo from "@/components/HeaderLogo";
@@ -112,20 +102,7 @@ export default function RootLayout() {
     AsyncStorage.setItem("subscriptionState", JSON.stringify(subscription));
   }, [subscription]);
 
-  const updateTripData = (newData: any) => {
-    setTripData((prevData) => {
-      // Find the key of the new data (locationInfo, travelers, dates, or budget)
-      const dataKey = Object.keys(newData)[0];
-
-      // Remove any existing data of the same type
-      const filteredData = prevData.filter((item) => !item[dataKey]);
-
-      // Add the new data
-      return [...filteredData, newData];
-    });
-  };
-
-  const colorScheme = useColorScheme();
+  // Removed unused helper function and color scheme
   const [loaded] = useFonts({
     outfit: require("@/assets/fonts/Outfit-Regular.ttf"),
     "outfit-medium": require("@/assets/fonts/Outfit-Medium.ttf"),

--- a/app/create-trip/_layout.tsx
+++ b/app/create-trip/_layout.tsx
@@ -1,8 +1,3 @@
-import {
-  DarkTheme,
-  DefaultTheme,
-  ThemeProvider,
-} from "@react-navigation/native";
 import { Stack, useRouter } from "expo-router";
 import { TouchableOpacity } from "react-native";
 import Ionicons from "@expo/vector-icons/Ionicons";

--- a/app/create-trip/select-dates.tsx
+++ b/app/create-trip/select-dates.tsx
@@ -9,7 +9,10 @@ import CustomButton from "@/components/CustomButton";
 import { CreateTripContext } from "@/context/CreateTripContext";
 import moment from "moment";
 
-export default function SelectDates() {
+// Expo Router requires a default export for each route. Using a
+// named component and exporting it explicitly helps ensure the bundler
+// recognizes the route component correctly.
+const SelectDates = () => {
   const router = useRouter();
   const { setTripData } = useContext(CreateTripContext);
 
@@ -73,9 +76,6 @@ export default function SelectDates() {
             fontFamily: "outfit",
             color: "#1E1B4B",
           }}
-          selectedRangeStartStyle={{ backgroundColor: "#9C00FF" }}
-          selectedRangeEndStyle={{ backgroundColor: "#9C00FF" }}
-          selectedRangeStyle={{ backgroundColor: "#9C00FF" }}
         />
       </View>
 
@@ -94,4 +94,6 @@ export default function SelectDates() {
       </View>
     </SafeAreaView>
   );
-}
+};
+
+export default SelectDates;

--- a/app/generate-trip.tsx
+++ b/app/generate-trip.tsx
@@ -112,8 +112,9 @@ export default function GenerateTrip() {
         const jsonStr = match[0].replace(/```json|```/gi, "");
         try {
           return JSON.parse(jsonStr);
-        } catch (_) {
+        } catch (err) {
           // Fallback to JSON5 for more forgiving parsing (handles trailing commas, single quotes, etc.)
+          console.error("JSON parse failed", err);
           return JSON5.parse(jsonStr);
         }
       };

--- a/app/trip-details/_layout.tsx
+++ b/app/trip-details/_layout.tsx
@@ -1,8 +1,3 @@
-import {
-  DarkTheme,
-  DefaultTheme,
-  ThemeProvider,
-} from "@react-navigation/native";
 import { Stack, useRouter } from "expo-router";
 import { TouchableOpacity } from "react-native";
 import Ionicons from "@expo/vector-icons/Ionicons";

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "react-native-svg": "15.11.2",
         "react-native-swiper": "^1.6.0",
         "react-native-web": "^0.20.0",
-        "sentry-expo": "^7.0.0",
+        "sentry-expo": "~7.0.0",
         "setimmediate": "^1.0.5",
         "tailwindcss": "^3.4.14",
         "tslib": "^2.8.1",
@@ -4475,39 +4475,53 @@
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.81.1.tgz",
-      "integrity": "sha512-E5xm27xrLXL10knH2EWDQsQYh5nb4SxxZzJ3sJwDGG9XGKzBdlp20UUhKqx00wixooVX9uCj3e4Jg8SvNB1hKg==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.52.1.tgz",
+      "integrity": "sha512-6N99rE+Ek0LgbqSzI/XpsKSLUyJjQ9nychViy+MP60p1x+hllukfTsDbNtUNrPlW0Bx+vqUrWKkAqmTFad94TQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry/core": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
+        "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/@sentry/browser": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.81.1.tgz",
-      "integrity": "sha512-DNtS7bZEnFPKVoGazKs5wHoWC0FwsOFOOMNeDvEfouUqKKbjO7+RDHbr7H6Bo83zX4qmZWRBf8V+3n3YPIiJFw==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.52.1.tgz",
+      "integrity": "sha512-HrCOfieX68t+Wj42VIkraLYwx8kN5311SdBkHccevWs2Y2dZU7R9iLbI87+nb5kpOPQ7jVWW7d6QI/yZmliYgQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.81.1",
-        "@sentry/core": "7.81.1",
-        "@sentry/replay": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry-internal/tracing": "7.52.1",
+        "@sentry/core": "7.52.1",
+        "@sentry/replay": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
+        "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/@sentry/browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/@sentry/cli": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.25.2.tgz",
-      "integrity": "sha512-lgt1QPaCfs/QZNXwyw3gvuBR2/CLwFSdU/oT7Bpxwizz8XVXhlKS98zJF1UVCy7SecsDSoOI0Z+B+X658cpquQ==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.5.tgz",
+      "integrity": "sha512-0tXjLDpaKB46851EMJ6NbP0o9/gdEaDSLAyjEtXxlVO6+RyhUj6x6jDwn0vis8n/7q0AvbIjAcJrot+TbZP+WQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4522,209 +4536,147 @@
       },
       "engines": {
         "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@sentry/cli-darwin": "2.25.2",
-        "@sentry/cli-linux-arm": "2.25.2",
-        "@sentry/cli-linux-arm64": "2.25.2",
-        "@sentry/cli-linux-i686": "2.25.2",
-        "@sentry/cli-linux-x64": "2.25.2",
-        "@sentry/cli-win32-i686": "2.25.2",
-        "@sentry/cli-win32-x64": "2.25.2"
-      }
-    },
-    "node_modules/@sentry/cli-darwin": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.25.2.tgz",
-      "integrity": "sha512-o1d5NnVUrc1dxDm56k7Co8tSTcOuxbApdxweVXXsiq20HblZCyIi7WxxRkAg4RfKx594sKGiw9uCVvECi+9UpA==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-arm": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.25.2.tgz",
-      "integrity": "sha512-n398jd87Ymejt5k/6RjCEjXAvntOWuqhBDANxzhgr5/9FzbODJ844g1mOpcxiIlduzKSzWlPbTEKQulMp2Mt4w==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.25.2.tgz",
-      "integrity": "sha512-lm5jaigV6xu9Gwo0wNk+bX6yVkl5k3gNXcSXcKCISFo+Teb7Zhf9IyXANPm4VY2DdiZAjPJt8gS1bu+Mn7irtQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-i686": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.25.2.tgz",
-      "integrity": "sha512-/YYx2gfqO5mkxyBgFcnDbZzkZ2+2xNarwrqWcqq3Qw0XlO9DWAQB2G+twV1RW/UfSU6fFIWErn94efh2EWmyzQ==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-linux-x64": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.25.2.tgz",
-      "integrity": "sha512-rRafqy84R5mYA4JEfNsUeN10af5euJnK7fgqYM0mJIaplHC2YEXT9aUYWoryWPZiYqmdNUhsA6lX7iynSW9pZw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "linux",
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-i686": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.25.2.tgz",
-      "integrity": "sha512-plT/gi41F+67g9AwrEm4avRXnjCtHCcnRnJ6zPu/iINGap8mvYQJSU/qM0oGwV6hRGg3JJN66XIvJPIuIs8P8w==",
-      "cpu": [
-        "x86",
-        "ia32"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@sentry/cli-win32-x64": {
-      "version": "2.25.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.25.2.tgz",
-      "integrity": "sha512-Mb6mAyPi9gIfpzF5MTk0JXgFP9nxka3Fb7JYn6AY4RW++sOjapkTrcXL2Gp3ZfQkWj5rFTgln4+eNmZPsD2gzA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.81.1.tgz",
-      "integrity": "sha512-tU37yAmckOGCw/moWKSwekSCWWJP15O6luIq+u7wal22hE88F3Vc5Avo8SeF3upnPR+4ejaOFH+BJTr6bgrs6Q==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.1.tgz",
+      "integrity": "sha512-36clugQu5z/9jrit1gzI7KfKbAUimjRab39JeR0mJ6pMuKLTTK7PhbpUAD4AQBs9qVeXN2c7h9SVZiSA0UDvkg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
+        "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/@sentry/hub": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.81.1.tgz",
-      "integrity": "sha512-25cvsI3HKiRLJBZGFC8ntuy7/yB8M1w8YLTjr3tIqydYmjFUX7f18w0iuWEtd204d8OQSPBJDapbGMdfkE5x6w==",
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.52.0.tgz",
+      "integrity": "sha512-w3d8Pmp3Fx2zbbjz6hAeIbsFEkLyrUs9YTGG2y8oCoTlAtGK+AjdG+Z0H/clAZONflD/je2EmFHCI0EuXE9tEw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry/core": "7.52.0",
+        "@sentry/types": "7.52.0",
+        "@sentry/utils": "7.52.0",
+        "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@sentry/hub/node_modules/@sentry/core": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.0.tgz",
+      "integrity": "sha512-BWdG6vCMeUeMhF4ILpxXTmw70JJvT1MGJcnv09oSupWHTmqy6I19YP6YcEyFuBL4jXPN51eCl7luIdLGJrPbOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.52.0",
+        "@sentry/utils": "7.52.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/@sentry/types": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
+      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/@sentry/utils": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
+      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.52.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.81.1.tgz",
-      "integrity": "sha512-DN5ONn0/LX5HHVPf1EBGHFssIZaZmLgkqUIeMqCNYBpB4DiOrJANnGwTcWKDPphqhdPxjnPv9AGRLaU0PdvvZQ==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.52.1.tgz",
+      "integrity": "sha512-4uejF01723wzEHjcP5AcNcV+Z/6U27b1LyaDu0jY3XDry98MMjhS/ASzecLpaEFxi3dh/jMTUrNp1u7WMj59Lg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1",
-        "localforage": "^1.8.1"
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
+        "localforage": "^1.8.1",
+        "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/@sentry/integrations/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/@sentry/replay": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.81.1.tgz",
-      "integrity": "sha512-4ueT0C4bYjngN/9p0fEYH10dTMLovHyk9HxJ6zSTgePvGVexhg+cSEHXisoBDwHeRZVnbIvsVM0NA7rmEDXJJw==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.52.1.tgz",
+      "integrity": "sha512-A+RaUmpU9/yBHnU3ATemc6wAvobGno0yf5R6fZYkAFoo2FCR2YG6AXxkTazymIf8v2DnLGaSDORYDPdhQClU9A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.81.1",
-        "@sentry/core": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
+        "@sentry/core": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.81.1.tgz",
-      "integrity": "sha512-dvJvGyctiaPMIQqa46k56Re5IODWMDxiHJ1UjBs/WYDLrmWFPGrEbyJ8w8CYLhYA+7qqrCyIZmHbWSTRIxstHw==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.1.tgz",
+      "integrity": "sha512-OMbGBPrJsw0iEXwZ2bJUYxewI1IEAU2e1aQGc0O6QW5+6hhCh+8HO8Xl4EymqwejjztuwStkl6G1qhK+Q0/Row==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.81.1.tgz",
-      "integrity": "sha512-gq+MDXIirHKxNZ+c9/lVvCXd6y2zaZANujwlFggRH2u9SRiPaIXVilLpvMm4uJqmqBMEcY81ArujExtHvkbCqg==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.1.tgz",
+      "integrity": "sha512-MPt1Xu/jluulknW8CmZ2naJ53jEdtdwCBSo6fXJvOTI0SDqwIPbXDVrsnqLAhVJuIN7xbkj96nuY/VBR6S5sWg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.81.1"
+        "@sentry/types": "7.52.1",
+        "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -16093,16 +16045,16 @@
       }
     },
     "node_modules/sentry-expo": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-7.2.0.tgz",
-      "integrity": "sha512-stVE2B1RgHxpcup8XU1UIGhoI3cta63guExInl6WYx3d5HsvIu8PZ0yDJnJGflYi9cKPAUCxErIQXMTrS0JQEw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-7.0.1.tgz",
+      "integrity": "sha512-8vmOy4R+qM1peQA9EP8rDGUMBhgMU1D5FyuWY9kfNGatmWuvEmlZpVgaXoXaNPIhPgf2TMrvQIlbqLHtTkoeSA==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.0",
-        "@sentry/integrations": "7.81.1",
-        "@sentry/react": "7.81.1",
-        "@sentry/react-native": "5.17.0",
-        "@sentry/types": "7.81.1",
+        "@sentry/integrations": "7.52.1",
+        "@sentry/react": "7.52.1",
+        "@sentry/react-native": "5.5.0",
+        "@sentry/types": "7.52.1",
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
       },
@@ -16113,16 +16065,90 @@
         "expo-device": "*"
       }
     },
-    "node_modules/sentry-expo/node_modules/@sentry/react": {
-      "version": "7.81.1",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.81.1.tgz",
-      "integrity": "sha512-kk0plP/mf8KgVLOiImIpp1liYysmh3Un8uXcVAToomSuHZPGanelFAdP0XhY+0HlWU9KIfxTjhMte1iSwQ8pYw==",
+    "node_modules/sentry-expo/node_modules/@sentry-internal/tracing": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.52.0.tgz",
+      "integrity": "sha512-o1YPcRGtC9tjeFCvWRJsbgK94zpExhzfxWaldAKvi3PuWEmPeewSdO/Q5pBIY1QonvSI+Q3gysLRcVlLYHhO5A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1",
-        "hoist-non-react-statics": "^3.3.2"
+        "@sentry/core": "7.52.0",
+        "@sentry/types": "7.52.0",
+        "@sentry/utils": "7.52.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
+      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
+      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.52.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/core": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.0.tgz",
+      "integrity": "sha512-BWdG6vCMeUeMhF4ILpxXTmw70JJvT1MGJcnv09oSupWHTmqy6I19YP6YcEyFuBL4jXPN51eCl7luIdLGJrPbOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.52.0",
+        "@sentry/utils": "7.52.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/core/node_modules/@sentry/types": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
+      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/core/node_modules/@sentry/utils": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
+      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.52.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/react": {
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.52.1.tgz",
+      "integrity": "sha512-RRH+GJE5TNg5QS86bSjSZuR2snpBTOO5/SU9t4BOqZMknzhMVTClGMm84hffJa9pMPMJPQ2fWQAbhrlD8RcF6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "7.52.1",
+        "@sentry/types": "7.52.1",
+        "@sentry/utils": "7.52.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=8"
@@ -16132,32 +16158,132 @@
       }
     },
     "node_modules/sentry-expo/node_modules/@sentry/react-native": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.17.0.tgz",
-      "integrity": "sha512-d0TLASMcpUtvw0A8zNznRyCskfH0kwfb3GzqMXXpfPJAG8vsBnY15EFOIc+czOLt6FbV9o3567bHYWhSW51Ssg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.5.0.tgz",
+      "integrity": "sha512-xrES+OAIu3HFhoQSuJjd16Hh02/mByuNoKUjF7e4WDGIiTew3aqlqeLjU7x4npmg5Vbt+ND5jR12u/NmdfArwg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "7.81.1",
-        "@sentry/cli": "2.25.2",
-        "@sentry/core": "7.81.1",
-        "@sentry/hub": "7.81.1",
-        "@sentry/integrations": "7.81.1",
-        "@sentry/react": "7.81.1",
-        "@sentry/types": "7.81.1",
-        "@sentry/utils": "7.81.1"
-      },
-      "bin": {
-        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+        "@sentry/browser": "7.52.0",
+        "@sentry/cli": "2.17.5",
+        "@sentry/core": "7.52.0",
+        "@sentry/hub": "7.52.0",
+        "@sentry/integrations": "7.52.0",
+        "@sentry/react": "7.52.0",
+        "@sentry/types": "7.52.0",
+        "@sentry/utils": "7.52.0"
       },
       "peerDependencies": {
-        "expo": ">=49.0.0",
         "react": ">=17.0.0",
         "react-native": ">=0.65.0"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/browser": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.52.0.tgz",
+      "integrity": "sha512-Sib0T24cQCqqqAhg+nZdfI7qNYGE03jiM3RbY7yG5UoycdnJzWEwrBVSzRTgg3Uya9TRTEGJ+d9vxPIU5TL7TA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.52.0",
+        "@sentry/core": "7.52.0",
+        "@sentry/replay": "7.52.0",
+        "@sentry/types": "7.52.0",
+        "@sentry/utils": "7.52.0",
+        "tslib": "^1.9.3"
       },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/integrations": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.52.0.tgz",
+      "integrity": "sha512-tqxYzgc71XdFD8MTCsVMCPef08lPY9jULE5Zi7TzjyV2AItDRJPkixG0qjwjOGwCtN/6KKz0lGPGYU8ZDxvsbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.52.0",
+        "@sentry/utils": "7.52.0",
+        "localforage": "^1.8.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/react": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.52.0.tgz",
+      "integrity": "sha512-VQxquyFFlvB81k7UER7tTJxjzbczNI2jqsw6nN1TVDrAIDt8/hT2x7m/M0FlWc88roBKuaMmbvzfNGWaL9abyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "7.52.0",
+        "@sentry/types": "7.52.0",
+        "@sentry/utils": "7.52.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "15.x || 16.x || 17.x || 18.x"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/types": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
+      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/utils": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
+      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.52.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/replay": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.52.0.tgz",
+      "integrity": "sha512-RRPALjDST2s7MHiMcUJ7Wo4WW7EWfUDYSG0LuhMT8DNc+ZsxQoFsLYX/yz8b3f0IUSr7xKBXP+aPeIy3jDAS2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.52.0",
+        "@sentry/types": "7.52.0",
+        "@sentry/utils": "7.52.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/replay/node_modules/@sentry/types": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
+      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sentry-expo/node_modules/@sentry/replay/node_modules/@sentry/utils": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
+      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.52.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sentry-expo/node_modules/react": {
@@ -16172,6 +16298,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sentry-expo/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/serialize-error": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-native-svg": "15.11.2",
     "react-native-swiper": "^1.6.0",
     "react-native-web": "^0.20.0",
-    "sentry-expo": "^7.0.0",
+    "sentry-expo": "~7.0.0",
     "setimmediate": "^1.0.5",
     "tailwindcss": "^3.4.14",
     "tslib": "^2.8.1",

--- a/services/tripMonitor.ts
+++ b/services/tripMonitor.ts
@@ -1,5 +1,6 @@
 import * as TaskManager from "expo-task-manager";
 import * as BackgroundTask from "expo-background-task";
+import Constants from "expo-constants";
 import { collection, getDocs } from "firebase/firestore";
 import { fetchFlightInfo } from "@/utils/travelpayouts";
 import { db } from "@/config/FirebaseConfig";
@@ -58,6 +59,12 @@ TaskManager.defineTask(TASK_NAME, async () => {
 // Register the background task
 export const registerTripMonitor = async () => {
   try {
+    // Background tasks are not available when running inside Expo Go.
+    if (Constants.appOwnership === "expo") {
+      console.warn("Skipping trip monitor registration in Expo Go");
+      return;
+    }
+
     const isRegistered = await TaskManager.isTaskRegisteredAsync(TASK_NAME);
     if (!isRegistered) {
       await BackgroundTask.registerTaskAsync(TASK_NAME, {


### PR DESCRIPTION
## Summary
- export SelectDates route explicitly and simplify calendar styling
- guard trip monitor registration in Expo Go
- pin sentry-expo to matching Expo SDK
- clean up unused imports and React hook deps across app

## Testing
- `CI=true npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895f753e79c8324949499f4b4aabc8e