### PR TITLE
Fix trip creation runtime crashes

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,6 +9,7 @@ import "react-native-reanimated";
 import { StatusBar } from "expo-status-bar";
 import "../global.css";
 import "react-native-get-random-values";
+import "deprecated-react-native-prop-types";
 import { CreateTripContext } from "@/context/CreateTripContext";
 import {
   ItineraryContext,

--- a/app/create-trip/flexible-dates.tsx
+++ b/app/create-trip/flexible-dates.tsx
@@ -125,7 +125,7 @@ const FlexibleDates = () => {
   };
 
   const selectRange = (r: FlexibleResult) => {
-    setTripData((prev) => {
+    setTripData((prev = []) => {
       const newData = prev.filter((item) => !item.dates);
       const totalDays = moment(r.end).diff(moment(r.start), "days") + 1;
       return [
@@ -139,7 +139,7 @@ const FlexibleDates = () => {
         },
       ];
     });
-    router.push("/create-trip/select-budget");
+    router.push("select-budget");
   };
 
   return (

--- a/app/create-trip/review-trip.tsx
+++ b/app/create-trip/review-trip.tsx
@@ -57,14 +57,14 @@ const ReviewTrip = () => {
           "Destination",
           locationInfo?.name || "Not selected",
           <Ionicons name="location-sharp" size={24} color="#9C00FF" />,
-          "/create-trip/search-place"
+          "search-place"
         )}
 
         {renderReviewItem(
           "Travelers",
           `${travelers?.type || "Not selected"} (${travelers?.count || "0"})`,
           <MaterialIcons name="people" size={24} color="#9C00FF" />,
-          "/create-trip/select-traveler"
+          "select-traveler"
         )}
 
         {renderReviewItem(
@@ -75,7 +75,7 @@ const ReviewTrip = () => {
               ).format("MMM D, YYYY")} (${dates.totalNumberOfDays} days)`
             : "Not selected",
           <FontAwesome5 name="calendar-alt" size={24} color="#9C00FF" />,
-          "/create-trip/select-dates"
+          "select-dates"
         )}
 
         {renderReviewItem(
@@ -86,7 +86,7 @@ const ReviewTrip = () => {
             size={24}
             color="#9C00FF"
           />,
-          "/create-trip/select-budget"
+          "select-budget"
         )}
       </View>
 

--- a/app/create-trip/search-place.tsx
+++ b/app/create-trip/search-place.tsx
@@ -36,7 +36,7 @@ export default function SearchPlace() {
             onPress={(data, details = null) => {
               if (!details) return;
 
-              setTripData((prev) => {
+              setTripData((prev = []) => {
                 const filtered = prev.filter((i) => !i.locationInfo);
                 return [
                   ...filtered,
@@ -51,7 +51,7 @@ export default function SearchPlace() {
                 ];
               });
 
-              router.push("/create-trip/select-origin-airport");
+              router.push("select-origin-airport");
             }}
             query={{
               key: Constants.expoConfig?.extra?.googlePlacesApiKey!,

--- a/app/create-trip/select-budget.tsx
+++ b/app/create-trip/select-budget.tsx
@@ -15,12 +15,12 @@ const SelectBudget = () => {
   const { setTripData } = useContext(CreateTripContext);
 
   const handleSelectBudget = (option: any) => {
-    setTripData((prev) => {
+    setTripData((prev = []) => {
       const newData = prev.filter((item) => !item.budget);
       return [...newData, { budget: { type: option.title } }];
     });
     // Navigate to next screen or handle selection
-    router.push("/create-trip/review-trip");
+    router.push("review-trip");
   };
 
   const renderItem = ({ item }: { item: any }) => (

--- a/app/create-trip/select-dates.tsx
+++ b/app/create-trip/select-dates.tsx
@@ -33,7 +33,7 @@ const SelectDates = () => {
 
     const days = moment(endDate).diff(moment(startDate), "days") + 1;
 
-    setTripData((prev) => {
+    setTripData((prev = []) => {
       const filtered = prev.filter((item) => !item.dates);
       return [
         ...filtered,
@@ -47,7 +47,7 @@ const SelectDates = () => {
       ];
     });
 
-    router.push("/create-trip/select-budget");
+    router.push("select-budget");
   };
 
   return (
@@ -88,7 +88,7 @@ const SelectDates = () => {
         />
         <CustomButton
           title="Flexible Dates"
-          onPress={() => router.push("/create-trip/flexible-dates")}
+          onPress={() => router.push("flexible-dates")}
           className="border-2 border-primary text-primary bg-background"
         />
       </View>

--- a/app/create-trip/select-origin-airport.tsx
+++ b/app/create-trip/select-origin-airport.tsx
@@ -86,7 +86,7 @@ export default function SelectOriginAirport() {
 
               if (!code || !coordinates) return;
 
-              setTripData((prev) => {
+              setTripData((prev = []) => {
                 const filtered = prev.filter((i) => !i.originAirport);
                 return [
                   ...filtered,
@@ -100,7 +100,7 @@ export default function SelectOriginAirport() {
                 ];
               });
 
-              router.push("/create-trip/select-traveler");
+              router.push("select-traveler");
             }}
             query={{
               key: Constants.expoConfig?.extra?.googlePlacesApiKey!,

--- a/app/create-trip/select-traveler.tsx
+++ b/app/create-trip/select-traveler.tsx
@@ -13,7 +13,7 @@ const SelectTraveler = () => {
   const { setTripData } = useContext(CreateTripContext);
 
   const handleSelectTraveler = (option: any) => {
-    setTripData((prev) => {
+    setTripData((prev = []) => {
       const newData = prev.filter((item) => !item.travelers);
       return [
         ...newData,
@@ -25,7 +25,7 @@ const SelectTraveler = () => {
         },
       ];
     });
-    router.push("/create-trip/select-dates");
+    router.push("select-dates");
   };
 
   const renderItem = ({ item }: { item: any }) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@sendgrid/mail": "^8.1.5",
         "@stripe/stripe-react-native": "0.45.0",
         "date-fns": "^4.1.0",
+        "deprecated-react-native-prop-types": "^5.0.0",
         "expo": "~53.0.20",
         "expo-auth-session": "~6.2.1",
         "expo-background-task": "~0.2.8",
@@ -7995,6 +7996,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/deprecated-react-native-prop-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-5.0.0.tgz",
+      "integrity": "sha512-cIK8KYiiGVOFsKdPMmm1L3tA/Gl+JopXL6F5+C7x39MyPsQYnP57Im/D6bNUzcborD7fcMwiwZqcBdBXXZucYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/normalize-colors": "^0.73.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/deprecated-react-native-prop-types/node_modules/@react-native/normalize-colors": {
+      "version": "0.73.2",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.73.2.tgz",
+      "integrity": "sha512-bRBcb2T+I88aG74LMVHaKms2p/T8aQd8+BZ7LuuzXlRfog1bMWWn/C5i0HVuvW4RPtXQYgIlGiXVDy9Ir1So/w==",
+      "license": "MIT"
     },
     "node_modules/destroy": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@sendgrid/mail": "^8.1.5",
     "@stripe/stripe-react-native": "0.45.0",
     "date-fns": "^4.1.0",
+    "deprecated-react-native-prop-types": "^5.0.0",
     "expo": "~53.0.20",
     "expo-auth-session": "~6.2.1",
     "expo-background-task": "~0.2.8",


### PR DESCRIPTION
## Summary
- prevent calendar crash by polyfilling deprecated React Native prop types
- guard trip data updates and use relative paths in trip creation screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689614fa3c0c8324ab45bda01ab5f424