### PR TITLE
fix: ensure tslib resolves correctly for expo router

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -18,10 +18,16 @@ config.resolver.assetExts = config.resolver.assetExts.filter(
   (ext) => ext !== "svg"
 );
 
+// Ensure tslib resolves to its CommonJS build to avoid runtime __extends errors
+config.resolver.extraNodeModules = {
+  ...(config.resolver.extraNodeModules || {}),
+  tslib: require.resolve("tslib/tslib.js"),
+};
+
 // Use the SVG transformer alongside the defaults
 config.transformer = {
   ...config.transformer,
   babelTransformerPath: require.resolve("react-native-svg-transformer"),
 };
-
 module.exports = withNativeWind(config, { input: "./global.css" });
+


### PR DESCRIPTION
## Summary
- Ensure Metro resolves `tslib` to the CommonJS build to avoid `__extends` runtime errors

## Testing
- `npm test -- --watchAll=false`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68962aada8bc8324b81434d786ba0f12