### PR TITLE
fix: resolve tslib to CommonJS build for Metro

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -22,6 +22,8 @@ config.resolver.assetExts = config.resolver.assetExts.filter(
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules || {}),
   tslib: require.resolve("tslib/tslib.js"),
+  "tslib/tslib.es6.js": require.resolve("tslib/tslib.js"),
+  "tslib/tslib.es6.mjs": require.resolve("tslib/tslib.js"),
 };
 
 // Use the SVG transformer alongside the defaults


### PR DESCRIPTION
## Summary
- ensure Metro resolves all tslib imports to the CommonJS build to avoid `__extends` runtime errors

## Testing
- `npm test -- --watchAll=false`
- `npx eslint metro.config.js`


------
https://chatgpt.com/codex/tasks/task_e_6896302c00ec8324959607afb628e23d