### PR TITLE
fix: resolve tslib CJS for metro

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -19,11 +19,12 @@ config.resolver.assetExts = config.resolver.assetExts.filter(
 );
 
 // Ensure tslib resolves to its CommonJS build to avoid runtime __extends errors
-config.resolver.extraNodeModules = {
-  ...(config.resolver.extraNodeModules || {}),
-  tslib: require.resolve("tslib/tslib.js"),
-  "tslib/tslib.es6.js": require.resolve("tslib/tslib.js"),
-  "tslib/tslib.es6.mjs": require.resolve("tslib/tslib.js"),
+const cjsTslib = require.resolve("tslib/tslib.js");
+config.resolver.alias = {
+  ...(config.resolver.alias || {}),
+  tslib: cjsTslib,
+  "tslib/tslib.es6.js": cjsTslib,
+  "tslib/tslib.es6.mjs": cjsTslib,
 };
 
 // Use the SVG transformer alongside the defaults


### PR DESCRIPTION
## Summary
- resolve tslib to CommonJS build in metro config to prevent `__extends` runtime failures and allow Expo Router layouts to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68963335048083249ee0f587f8ae8490