### PR TITLE
fix: restore root layout default export

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,6 @@
 import "setimmediate";
 import "@/config/sentry";
+import "tslib";
 import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
@@ -26,7 +27,7 @@ import {
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
-export default function RootLayout() {
+function RootLayout() {
   const [tripData, setTripData] = useState<any[]>([]);
   const [itineraries, setItineraries] = useState<StoredItinerary[]>([]);
   const [preferences, setPreferences] = useState<UserPreferences>({
@@ -153,3 +154,5 @@ export default function RootLayout() {
     </>
   );
 }
+
+export default RootLayout;


### PR DESCRIPTION
## Summary
- ensure RootLayout is exported as default component
- load tslib to avoid runtime `__extends` errors

## Testing
- `CI=1 npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896451427848324a5052a0b70404054