### PR TITLE
fix: ensure tslib global for expo-router

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,6 @@
+import * as tslib from "tslib";
 import "setimmediate";
 import "@/config/sentry";
-import "tslib";
 import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
@@ -23,6 +23,8 @@ import {
   SubscriptionState,
   defaultSubscriptionState,
 } from "@/types/subscription";
+
+(globalThis as any).tslib = tslib;
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();


### PR DESCRIPTION
## Summary
- ensure tslib helpers are globally available to satisfy Expo Router

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_689648e7df3483249b10b93f7e01b63a