### PR TITLE
feat: weather-aware itinerary adjustments

### DIFF
--- a/components/ItineraryDetails.tsx
+++ b/components/ItineraryDetails.tsx
@@ -3,7 +3,9 @@ import { View, Text, ScrollView, TouchableOpacity, Linking } from "react-native"
 import { Ionicons } from "@expo/vector-icons";
 import moment from "moment";
 import CustomButton from "@/components/CustomButton";
+import WeatherSuggestionChip from "@/components/WeatherSuggestionChip";
 import { DayPlan } from "@/context/ItineraryContext";
+import { logWeatherAdjustment } from "@/utils/weatherLog";
 import { generateHotelLink } from "@/utils/travelpayouts";
 import { recordAffiliateClick } from "@/services/affiliate";
 
@@ -82,30 +84,42 @@ const ItineraryDetails: React.FC<Props> = ({ plan }) => {
               </Text>
               <Text className="text-text-primary">{collapsed[index] ? "+" : "-"}</Text>
             </TouchableOpacity>
-            {!collapsed[index] && (
-              <View className="p-4 space-y-3">
-                {(["morning", "afternoon", "evening", "night"] as const).map(
-                  (slot) => {
-                    const text = (d.schedule as any)[slot];
-                    if (!text) return null;
-                    return (
-                      <View key={slot} className="mb-2 flex-row">
-                        <Ionicons
-                          name={slotIcon[slot] as any}
-                          size={20}
-                          color="#9C00FF"
-                          style={{ marginRight: 8, marginTop: 2 }}
-                        />
-                        <View className="flex-1">
-                          <Text className="font-outfit-medium capitalize">
-                            {slot}
-                          </Text>
-                          {linkifyText(text)}
+              {!collapsed[index] && (
+                <View className="p-4 space-y-3">
+                  {d.weatherSuggestion && (
+                    <WeatherSuggestionChip
+                      message={d.weatherSuggestion}
+                      onApply={() => logWeatherAdjustment(d.weatherSuggestion!)}
+                    />
+                  )}
+                  {(["morning", "afternoon", "evening", "night"] as const).map(
+                    (slot) => {
+                      const activity = (d.schedule as any)[slot];
+                      if (!activity) return null;
+                      return (
+                        <View key={slot} className="mb-2 flex-row">
+                          <Ionicons
+                            name={slotIcon[slot] as any}
+                            size={20}
+                            color="#9C00FF"
+                            style={{ marginRight: 8, marginTop: 2 }}
+                          />
+                          <View className="flex-1">
+                            <Text className="font-outfit-medium capitalize flex-row items-center">
+                              {slot}
+                              <Ionicons
+                                name={activity.indoor ? "home" : "leaf"}
+                                size={16}
+                                color={activity.indoor ? "#9C00FF" : "#16a34a"}
+                                style={{ marginLeft: 4 }}
+                              />
+                            </Text>
+                            {linkifyText(activity.name)}
+                          </View>
                         </View>
-                      </View>
-                    );
-                  }
-                )}
+                      );
+                    }
+                  )}
                 {d.food_recommendations ? (
                   <View className="flex-row">
                     <Ionicons

--- a/components/WeatherSuggestionChip.tsx
+++ b/components/WeatherSuggestionChip.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Text, TouchableOpacity, View } from "react-native";
+
+interface Props {
+  message: string;
+  onApply: () => void;
+}
+
+const WeatherSuggestionChip: React.FC<Props> = ({ message, onApply }) => (
+  <TouchableOpacity
+    onPress={onApply}
+    className="flex-row items-center bg-secondary/20 px-3 py-1 rounded-full mt-2"
+  >
+    <View className="mr-2">
+      <Text className="text-text-primary">{message}</Text>
+    </View>
+    <Text className="text-primary font-outfit-bold">Apply</Text>
+  </TouchableOpacity>
+);
+
+export default WeatherSuggestionChip;

--- a/context/ItineraryContext.ts
+++ b/context/ItineraryContext.ts
@@ -1,14 +1,23 @@
 import { createContext } from "react";
 
+export interface ActivitySlot {
+  /** Title or brief description of the activity */
+  name: string;
+  /** Whether the activity takes place indoors */
+  indoor: boolean;
+}
+
 export interface DayPlan {
   day: number;
   date: string;
   schedule: {
-    morning: string;
-    afternoon: string;
-    evening: string;
-    night: string;
+    morning?: ActivitySlot;
+    afternoon?: ActivitySlot;
+    evening?: ActivitySlot;
+    night?: ActivitySlot;
   };
+  /** Optional weather-based suggestion for this day */
+  weatherSuggestion?: string;
   food_recommendations: string;
   stay_options: string;
   optional_activities: { name: string; booking_url: string }[];

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "react-native-web": "^0.20.0",
         "setimmediate": "^1.0.5",
         "tailwindcss": "^3.4.14",
-        "undefined": "\\"
+        
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -17569,10 +17569,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undefined": {
-      "resolved": "../../..",
-      "link": true
     },
     "node_modules/undici": {
       "version": "6.21.3",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "tailwindcss": "^3.4.14",
     "expo-dev-client": "~5.2.4",
     "expo-location": "~18.1.6",
-    "expo-background-fetch": "~13.1.6",
-    "undefined": "\\"
+    "expo-background-fetch": "~13.1.6"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/packages/agent/weatherScheduler.ts
+++ b/packages/agent/weatherScheduler.ts
@@ -1,0 +1,88 @@
+import { getForecast } from "../providers/weather";
+
+export interface ActivitySlot {
+  name: string;
+  indoor: boolean;
+}
+
+export interface DayPlan {
+  day: number;
+  date: string; // ISO date
+  schedule: {
+    morning?: ActivitySlot;
+    afternoon?: ActivitySlot;
+    evening?: ActivitySlot;
+    night?: ActivitySlot;
+  };
+}
+
+export interface SwapSuggestion {
+  fromDay: number;
+  fromSlot: keyof DayPlan["schedule"];
+  toDay: number;
+  toSlot: keyof DayPlan["schedule"];
+  reason: string;
+}
+
+const slotHour: Record<keyof DayPlan["schedule"], number> = {
+  morning: 9,
+  afternoon: 14,
+  evening: 18,
+  night: 21,
+};
+
+/**
+ * Analyse the next 48 hours and propose swaps of outdoor activities with
+ * later indoor ones when rain is forecast.
+ */
+export const suggestWeatherSwaps = async (
+  plan: DayPlan[],
+  lat: number,
+  lng: number
+): Promise<SwapSuggestion[]> => {
+  const now = new Date();
+  const horizon = new Date(now.getTime() + 48 * 60 * 60 * 1000);
+  const dates: Date[] = [];
+  plan.forEach((d) => {
+    const dt = new Date(d.date);
+    if (dt <= horizon) dates.push(dt);
+  });
+  if (!dates.length) return [];
+  const forecast = await getForecast(lat, lng, dates);
+  const forecastMap = new Map<string, number>();
+  forecast.forEach((h) => forecastMap.set(h.time, h.precipitation));
+
+  const suggestions: SwapSuggestion[] = [];
+  for (let i = 0; i < plan.length; i++) {
+    const day = plan[i];
+    const dayDate = new Date(day.date);
+    if (dayDate > horizon) continue;
+    (Object.keys(slotHour) as (keyof DayPlan["schedule"])[]).forEach((slot) => {
+      const activity = day.schedule[slot];
+      if (!activity || activity.indoor) return;
+      const hour = slotHour[slot];
+      const slotTime = new Date(dayDate.getTime() + hour * 3600 * 1000)
+        .toISOString()
+        .slice(0, 13) + ":00";
+      const precip = forecastMap.get(slotTime) || 0;
+      if (precip < 50) return; // only worry if >=50% chance of rain
+      for (let j = i + 1; j < plan.length; j++) {
+        const other = plan[j];
+        const indoorSlot = (Object.keys(slotHour) as (keyof DayPlan["schedule"])[]).find(
+          (s) => other.schedule[s]?.indoor
+        );
+        if (indoorSlot) {
+          suggestions.push({
+            fromDay: day.day,
+            fromSlot: slot,
+            toDay: other.day,
+            toSlot: indoorSlot,
+            reason: `Rain expected at ${slotTime.slice(11, 16)}`,
+          });
+          break;
+        }
+      }
+    });
+  }
+  return suggestions;
+};

--- a/packages/providers/weather.ts
+++ b/packages/providers/weather.ts
@@ -1,0 +1,41 @@
+export interface ForecastHour {
+  time: string; // ISO string
+  precipitation: number; // probability 0-100
+}
+
+/**
+ * Fetch hourly precipitation forecast for given coordinates and dates.
+ * Dates can span multiple days; the API will return hourly slots between
+ * the earliest and latest date in the array.
+ */
+export const getForecast = async (
+  lat: number,
+  lng: number,
+  dates: Date[]
+): Promise<ForecastHour[]> => {
+  if (!dates.length) return [];
+  const sorted = [...dates].sort((a, b) => a.getTime() - b.getTime());
+  const start = sorted[0].toISOString().slice(0, 10);
+  const end = sorted[sorted.length - 1].toISOString().slice(0, 10);
+
+  try {
+    const apiKey = process.env.WEATHER_API_KEY;
+    const url =
+      `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lng}` +
+      `&hourly=precipitation_probability&start_date=${start}&end_date=${end}&timezone=UTC` +
+      (apiKey ? `&apikey=${apiKey}` : "");
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`status ${res.status}`);
+    const data = await res.json();
+    const hours: ForecastHour[] = [];
+    const times: string[] = data.hourly?.time || [];
+    const precip: number[] = data.hourly?.precipitation_probability || [];
+    for (let i = 0; i < times.length; i++) {
+      hours.push({ time: times[i], precipitation: precip[i] || 0 });
+    }
+    return hours;
+  } catch (e) {
+    console.error("weather forecast failed", e);
+    return [];
+  }
+};

--- a/types/itinerary.ts
+++ b/types/itinerary.ts
@@ -3,6 +3,8 @@ export interface Booking {
   provider: string;
   reference?: string;
   url?: string;
+  /** For activity bookings, whether it is indoors */
+  indoor?: boolean;
 }
 
 export interface Destination {

--- a/utils/weatherLog.ts
+++ b/utils/weatherLog.ts
@@ -1,0 +1,5 @@
+export const weatherLog: string[] = [];
+
+export const logWeatherAdjustment = (entry: string) => {
+  weatherLog.push(`${Date.now()}:${entry}`);
+};


### PR DESCRIPTION
## Summary
- add weather forecast provider
- tag itinerary activities as indoor or outdoor
- suggest weather-based swaps and surface inline chip with apply logging

## Testing
- `npm run lint`
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b6f5ae02848324b41b5767fc237e6e