### PR TITLE
feat: add CO2 estimates and sorting for flights

### DIFF
--- a/packages/impact/co2.ts
+++ b/packages/impact/co2.ts
@@ -1,0 +1,32 @@
+export interface FlightSegment {
+  /** distance of the segment in kilometers */
+  distanceKm: number;
+  /** optional aircraft type (e.g. A320, B738) */
+  aircraft?: string;
+}
+
+// Approximate emission factors (kg CO2 per passenger-km) for some aircraft.
+// Defaults to 0.115 kg/km when type is unknown.
+const BASE_FACTOR = 0.115;
+const AIRCRAFT_FACTORS: Record<string, number> = {
+  A320: 0.1,
+  A319: 0.105,
+  A321: 0.11,
+  B738: 0.11,
+  B737: 0.11,
+  B744: 0.14,
+  B788: 0.095,
+};
+
+/**
+ * Roughly estimate the CO2 emissions for a set of flight segments.
+ * Returned value is in kilograms of CO2 equivalent.
+ */
+export function estimateFlightCO2(segments: FlightSegment[]): number {
+  return segments.reduce((total, seg) => {
+    const factor =
+      (seg.aircraft && AIRCRAFT_FACTORS[seg.aircraft.toUpperCase()]) ||
+      BASE_FACTOR;
+    return total + seg.distanceKm * factor;
+  }, 0);
+}


### PR DESCRIPTION
## Summary
- estimate flight CO2 emissions with new impact module
- include CO2 data in travelpayouts flight offers
- show emissions, sort greener-first and filter by footprint in Discover tab

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b7ec80c2a88324995d026a4b4b9b4a