### PR TITLE
feat: add visa and safety advisories

### DIFF
--- a/app/trip-details/index.tsx
+++ b/app/trip-details/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import moment from "moment";
 import CustomButton from "@/components/CustomButton";
+import PreFlightChecklist from "@/components/PreFlightChecklist";
 
 const DEFAULT_IMAGE_URL =
   "https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?q=80&w=2071&auto=format&fit=crop";
@@ -44,6 +45,10 @@ const TripDetails = () => {
     startDate && endDate ? moment(endDate).diff(startDate, "days") + 1 : 0;
   const budget = parsedTripData?.find((item: any) => item.budget)?.budget?.type;
 
+  const countryNameToCode: Record<string, string> = { Japan: "JP" };
+  const destinationCode = countryNameToCode[locationInfo?.country as string] || "";
+  const dateArr = [startDate, endDate].filter(Boolean) as Date[];
+
   return (
     <ScrollView className="flex-1 bg-background">
       <Image
@@ -71,14 +76,17 @@ const TripDetails = () => {
           <Text className="text-lg font-outfit text-text-primary">
             {travelers?.type} ({travelers?.count})
           </Text>
-          <Text className="text-lg font-outfit text-text-primary">
-            Budget Type: {budget ?? "N/A"}
+        <Text className="text-lg font-outfit text-text-primary">
+          Budget Type: {budget ?? "N/A"}
+        </Text>
+        {destinationCode ? (
+          <PreFlightChecklist destinationCountry={destinationCode} dates={dateArr} />
+        ) : null}
+        <View className="flex mt-10 items-center justify-center">
+          <Text className="text-lg font-outfit-medium text-text-primary">
+            Want to see flights, hotel recommendations and more plan details?
           </Text>
-          <View className="flex mt-10 items-center justify-center">
-            <Text className="text-lg font-outfit-medium text-text-primary">
-              Want to see flights, hotel recommendations and more plan details?
-            </Text>
-          </View>
+        </View>
         </View>
 
         <CustomButton

--- a/components/PreFlightChecklist.tsx
+++ b/components/PreFlightChecklist.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, TextInput, Button, Switch, Linking } from "react-native";
+import { getPassportCountry, setPassportCountry } from "@/services/passport";
+import { getVisaRules, VisaRule } from "@/packages/providers/visa";
+import { getAdvisories, Advisory } from "@/packages/providers/safety";
+
+interface Props {
+  destinationCountry: string;
+  dates: Date[];
+}
+
+const PreFlightChecklist: React.FC<Props> = ({ destinationCountry, dates }) => {
+  const [passport, setPassport] = useState<string | null>(null);
+  const [visa, setVisa] = useState<VisaRule | null>(null);
+  const [advisory, setAdvisory] = useState<Advisory | null>(null);
+  const [input, setInput] = useState("");
+  const [consent, setConsent] = useState(false);
+
+  useEffect(() => {
+    getPassportCountry().then((p) => setPassport(p));
+  }, []);
+
+  useEffect(() => {
+    const run = async () => {
+      if (passport) {
+        const v = await getVisaRules(passport, destinationCountry, dates);
+        const a = await getAdvisories(destinationCountry);
+        setVisa(v);
+        setAdvisory(a);
+      }
+    };
+    run();
+  }, [passport, destinationCountry, dates]);
+
+  const savePassport = async () => {
+    if (!consent || !input) return;
+    await setPassportCountry(input.trim());
+    setPassport(input.trim().toUpperCase());
+  };
+
+  if (!passport) {
+    return (
+      <View className="p-4 border border-primary rounded-xl mt-4 space-y-2">
+        <Text className="font-outfit-bold text-text-primary">
+          Share Passport Country
+        </Text>
+        <Text className="text-text-primary">
+          To check visa rules we store your passport country securely. No numbers
+          or additional data is saved.
+        </Text>
+        <TextInput
+          value={input}
+          onChangeText={setInput}
+          placeholder="Country code (e.g., FR)"
+          className="border p-2"
+        />
+        <View className="flex-row items-center">
+          <Switch value={consent} onValueChange={setConsent} />
+          <Text className="ml-2 text-text-primary">I consent to storing my passport country</Text>
+        </View>
+        <Button title="Save" onPress={savePassport} disabled={!consent || !input} />
+      </View>
+    );
+  }
+
+  return (
+    <View className="p-4 border border-primary rounded-xl mt-4 space-y-2">
+      <Text className="font-outfit-bold text-text-primary">Pre-Flight Checklist</Text>
+      {visa && (
+        <Text className="text-text-primary">Visa: {visa.summary}</Text>
+      )}
+      {advisory && (
+        <Text className="text-text-primary">Safety: {advisory.message}</Text>
+      )}
+      {visa?.url && (
+        <Text
+          className="text-accent underline"
+          onPress={() => Linking.openURL(visa.url!)}
+        >
+          Learn more
+        </Text>
+      )}
+    </View>
+  );
+};
+
+export default PreFlightChecklist;

--- a/packages/providers/safety.ts
+++ b/packages/providers/safety.ts
@@ -1,0 +1,33 @@
+export interface Advisory {
+  level: "low" | "medium" | "high";
+  message: string;
+}
+
+const cache = new Map<string, Advisory>();
+
+/** Fetch basic travel advisory for a destination country code. */
+export const getAdvisories = async (
+  destination: string
+): Promise<Advisory> => {
+  if (cache.has(destination)) return cache.get(destination)!;
+  try {
+    const res = await fetch(
+      `https://www.travel-advisory.info/api?countrycode=${destination}`
+    );
+    if (!res.ok) throw new Error(`status ${res.status}`);
+    const data = await res.json();
+    const adv = data?.data?.[destination]?.advisory;
+    const score = adv?.score ?? 0;
+    const level: Advisory["level"] =
+      score >= 4 ? "high" : score >= 3 ? "medium" : "low";
+    const result: Advisory = {
+      level,
+      message: adv?.message || "No advisory data available.",
+    };
+    cache.set(destination, result);
+    return result;
+  } catch (e) {
+    console.error("advisory fetch failed", e);
+    return { level: "low", message: "Verify local advisories." };
+  }
+};

--- a/packages/providers/visa.ts
+++ b/packages/providers/visa.ts
@@ -1,0 +1,36 @@
+export interface VisaRule {
+  /** Short summary like "visa-free up to 90 days" */
+  summary: string;
+  /** Optional URL to official source */
+  url?: string;
+}
+
+// Minimal data for demo purposes
+const schengen = new Set([
+  "AT","BE","CZ","DE","DK","EE","ES","FI","FR","GR","HU",
+  "IS","IT","LI","LT","LU","LV","MT","NL","NO","PL","PT",
+  "SE","SI","SK","CH"
+]);
+
+/**
+ * Determine visa rules based on passport and destination country codes.
+ * Returns a friendly summary or a generic message if unknown.
+ */
+export const getVisaRules = async (
+  passport: string,
+  destination: string,
+  _dates: Date[]
+): Promise<VisaRule> => {
+  // Example: Schengen area passport holder visiting Japan
+  if (destination === "JP" && schengen.has(passport)) {
+    return {
+      summary: "visa-free up to 90 days",
+      url: "https://www.mofa.go.jp/j_info/visit/visa/short/novisa.html",
+    };
+  }
+
+  return {
+    summary: "Verify requirements",
+    url: "https://www.iatatravelcentre.com/",
+  };
+};

--- a/services/passport.ts
+++ b/services/passport.ts
@@ -1,0 +1,15 @@
+import * as SecureStore from "expo-secure-store";
+
+const KEY = "passportCountry";
+
+export const getPassportCountry = async (): Promise<string | null> => {
+  try {
+    return await SecureStore.getItemAsync(KEY);
+  } catch {
+    return null;
+  }
+};
+
+export const setPassportCountry = async (code: string) => {
+  await SecureStore.setItemAsync(KEY, code.toUpperCase());
+};


### PR DESCRIPTION
## Summary
- add visa rules provider with sample Schengen → Japan support
- fetch and cache basic travel advisories
- secure passport country storage with consent and pre-flight checklist panel

## Testing
- `npm run lint`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b7f22a3b9083249f68e41dd9f82643