### PR TITLE
feat: add audit and data retention utilities

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, TouchableOpacity, Switch } from "react-native";
+import { View, Text, TouchableOpacity, Switch, Alert } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { auth } from "@/config/FirebaseConfig";
 import { router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import CustomButton from "@/components/CustomButton";
+import { exportUserData, deleteUserData } from "@/services/userData";
 import {
   getNotificationPreferences,
   setNotificationPreferences,
@@ -136,6 +137,37 @@ export default function Profile() {
             <Text className="ml-3 font-outfit">Disruptions (always on)</Text>
           </View>
         </View>
+      </View>
+
+      {/* Data & Privacy */}
+      <View className="mb-8">
+        <Text className="text-xl font-outfit-bold mb-4">Data & Privacy</Text>
+
+        <TouchableOpacity
+          className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3"
+          onPress={async () => {
+            const data = await exportUserData(user?.uid);
+            Alert.alert("Your Data", JSON.stringify(data));
+          }}
+        >
+          <View className="flex-row items-center">
+            <Ionicons name="download-outline" size={24} color="#9C00FF" />
+            <Text className="ml-3 font-outfit">Export My Data</Text>
+          </View>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          className="flex-row items-center justify-between bg-background p-4 rounded-xl"
+          onPress={async () => {
+            await deleteUserData(user?.uid);
+            Alert.alert("Data Deleted");
+          }}
+        >
+          <View className="flex-row items-center">
+            <Ionicons name="trash-outline" size={24} color="#9C00FF" />
+            <Text className="ml-3 font-outfit">Delete My Data</Text>
+          </View>
+        </TouchableOpacity>
       </View>
 
       {/* Logout Button */}

--- a/packages/db/schemas/ChatLog.ts
+++ b/packages/db/schemas/ChatLog.ts
@@ -1,0 +1,30 @@
+export interface ChatLog {
+  id: string;
+  userPrompt?: string;
+  agentResponse?: string;
+  summary: string;
+  timestamp: Date;
+}
+
+const chatLogs: ChatLog[] = [];
+
+export const addChatLog = (entry: ChatLog) => {
+  chatLogs.push(entry);
+  purgeOldChatLogs();
+};
+
+export const getChatLogs = () => chatLogs;
+
+export const purgeOldChatLogs = () => {
+  const cutoff = new Date(Date.now() - 180 * 24 * 60 * 60 * 1000);
+  for (const log of chatLogs) {
+    if (log.timestamp < cutoff) {
+      log.userPrompt = undefined;
+      log.agentResponse = undefined;
+    }
+  }
+};
+
+export const clearChatLogs = () => {
+  chatLogs.length = 0;
+};

--- a/packages/db/schemas/DataAccessLog.ts
+++ b/packages/db/schemas/DataAccessLog.ts
@@ -1,0 +1,19 @@
+export interface DataAccessLog {
+  id: string;
+  actor: string;
+  resource: string;
+  action: 'read' | 'write' | 'export' | 'delete';
+  timestamp: Date;
+}
+
+const dataAccessLogs: DataAccessLog[] = [];
+
+export const logDataAccess = (entry: DataAccessLog) => {
+  dataAccessLogs.push(entry);
+};
+
+export const getDataAccessLogs = () => dataAccessLogs;
+
+export const clearDataAccessLogs = () => {
+  dataAccessLogs.length = 0;
+};

--- a/packages/db/schemas/DecisionLog.ts
+++ b/packages/db/schemas/DecisionLog.ts
@@ -11,7 +11,15 @@ export interface DecisionLog {
 const decisionLogs: DecisionLog[] = [];
 
 export const logDecision = (entry: DecisionLog) => {
+  if (entry.payload) {
+    delete (entry.payload as any).passportId;
+    delete (entry.payload as any).passportNumber;
+  }
   decisionLogs.push(entry);
 };
 
 export const getDecisionLogs = () => decisionLogs;
+
+export const clearDecisionLogs = () => {
+  decisionLogs.length = 0;
+};

--- a/services/passport.ts
+++ b/services/passport.ts
@@ -1,10 +1,19 @@
 import * as SecureStore from "expo-secure-store";
+import { logDataAccess } from "@/packages/db/schemas/DataAccessLog";
 
 const KEY = "passportCountry";
 
 export const getPassportCountry = async (): Promise<string | null> => {
   try {
-    return await SecureStore.getItemAsync(KEY);
+    const value = await SecureStore.getItemAsync(KEY);
+    logDataAccess({
+      id: Date.now().toString(),
+      actor: "local-user",
+      resource: "passportCountry",
+      action: "read",
+      timestamp: new Date(),
+    });
+    return value;
   } catch {
     return null;
   }
@@ -12,4 +21,11 @@ export const getPassportCountry = async (): Promise<string | null> => {
 
 export const setPassportCountry = async (code: string) => {
   await SecureStore.setItemAsync(KEY, code.toUpperCase());
+  logDataAccess({
+    id: Date.now().toString(),
+    actor: "local-user",
+    resource: "passportCountry",
+    action: "write",
+    timestamp: new Date(),
+  });
 };

--- a/services/userData.ts
+++ b/services/userData.ts
@@ -1,0 +1,43 @@
+import * as SecureStore from "expo-secure-store";
+import { getDecisionLogs, clearDecisionLogs } from "@/packages/db/schemas/DecisionLog";
+import {
+  getDataAccessLogs,
+  clearDataAccessLogs,
+  logDataAccess,
+} from "@/packages/db/schemas/DataAccessLog";
+import { getChatLogs, clearChatLogs, purgeOldChatLogs } from "@/packages/db/schemas/ChatLog";
+import { getPassportCountry } from "@/services/passport";
+
+const PASSPORT_KEY = "passportCountry";
+
+export const exportUserData = async (userId?: string) => {
+  purgeOldChatLogs();
+  const data = {
+    passportCountry: await getPassportCountry(),
+    decisions: getDecisionLogs(),
+    access: getDataAccessLogs(),
+    chats: getChatLogs(),
+  };
+  logDataAccess({
+    id: Date.now().toString(),
+    actor: userId || "local-user",
+    resource: "userData",
+    action: "export",
+    timestamp: new Date(),
+  });
+  return data;
+};
+
+export const deleteUserData = async (userId?: string) => {
+  await SecureStore.deleteItemAsync(PASSPORT_KEY);
+  clearDecisionLogs();
+  clearDataAccessLogs();
+  clearChatLogs();
+  logDataAccess({
+    id: Date.now().toString(),
+    actor: userId || "local-user",
+    resource: "userData",
+    action: "delete",
+    timestamp: new Date(),
+  });
+};

--- a/utils/chatAgent.ts
+++ b/utils/chatAgent.ts
@@ -4,6 +4,7 @@ import {
   executeAgentFunction,
   TravelFunctionName,
 } from "@/utils/agentFunctions";
+import { addChatLog } from "@/packages/db/schemas/ChatLog";
 
 /**
  * runTravelAgent
@@ -35,5 +36,13 @@ export const runTravelAgent = async (prompt: string) => {
       response = result.response;
     }
   }
-  return response.text();
+  const reply = response.text();
+  addChatLog({
+    id: Date.now().toString(),
+    userPrompt: prompt,
+    agentResponse: reply,
+    summary: reply,
+    timestamp: new Date(),
+  });
+  return reply;
 };


### PR DESCRIPTION
## Summary
- log sensitive data access with new DataAccessLog
- purge chat history after 180 days and capture summaries
- allow users to export or delete their stored data from profile screen

## Testing
- `npm test -- --watchAll=false`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b800770d948324b9486ca9c0810a92