### PR TITLE
fix(firebase): update auth persistence import

### DIFF
--- a/config/FirebaseConfig.ts
+++ b/config/FirebaseConfig.ts
@@ -3,8 +3,12 @@
 import { Platform } from "react-native";
 import Constants from "expo-constants";
 import { initializeApp, FirebaseApp } from "firebase/app";
-import { getAuth, initializeAuth, Auth } from "firebase/auth";
-import { getReactNativePersistence } from "firebase/auth/react-native";
+import {
+  getAuth,
+  initializeAuth,
+  getReactNativePersistence,
+  Auth,
+} from "firebase/auth";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { getFirestore, Firestore } from "firebase/firestore";
 


### PR DESCRIPTION
## Summary
- fix FirebaseConfig import by sourcing getReactNativePersistence from `firebase/auth`

## Testing
- `npm test -- --watchAll=false` (fails: Jest encountered an unexpected token in @react-native/js-polyfills)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b97d98607c8324a1c9fc2a6c167de3