### PR TITLE
Fix bundling issue by guarding Node-specific fs usage

### DIFF
--- a/packages/notify/index.ts
+++ b/packages/notify/index.ts
@@ -83,14 +83,18 @@ export async function notify(
 
   const useMock = !process.env.EXPO_ACCESS_TOKEN && !process.env.RESEND_API_KEY;
   if (useMock) {
-    const fs = await import('fs');
-    const path = await import('path');
-    const dir = path.resolve(__dirname, '../../reports/notifications');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, `${Date.now()}-${type}.json`),
-      JSON.stringify({ userId, type, payload }, null, 2)
-    );
+    if (typeof process !== 'undefined' && (process as any)?.versions?.node) {
+      const fs: any = (eval('require') as any)('fs');
+      const path: any = (eval('require') as any)('path');
+      const dir = path.resolve(process.cwd(), 'reports/notifications');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, `${Date.now()}-${type}.json`),
+        JSON.stringify({ userId, type, payload }, null, 2)
+      );
+    } else {
+      console.log('Mock notification', { userId, type, payload });
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- Avoid bundling Node `fs` and `path` modules in `packages/notify` by dynamically requiring them only in Node environments
- Fallback to console logging when native `fs` is unavailable

## Testing
- `npm run lint packages/notify/index.ts`
- `npm test -- --watchAll=false` *(fails: SyntaxError in react-native/js-polyfills)*
- `npx tsc packages/notify/index.ts --noEmit --skipLibCheck` *(fails: missing libs like Promise, process)*

------
https://chatgpt.com/codex/tasks/task_e_68b983f1e2748324bcbd0ba675341721