### PR TITLE
Fix bundling issue by guarding Node-specific fs usage

### DIFF
--- a/packages/notify/index.ts
+++ b/packages/notify/index.ts
@@ -83,14 +83,18 @@ export async function notify(
 
   const useMock = !process.env.EXPO_ACCESS_TOKEN && !process.env.RESEND_API_KEY;
   if (useMock) {
-    const fs = await import('fs');
-    const path = await import('path');
-    const dir = path.resolve(__dirname, '../../reports/notifications');
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, `${Date.now()}-${type}.json`),
-      JSON.stringify({ userId, type, payload }, null, 2)
-    );
+    if (typeof process !== 'undefined' && (process as any)?.versions?.node) {
+      const fs: any = (eval('require') as any)('fs');
+      const path: any = (eval('require') as any)('path');
+      const dir = path.resolve(process.cwd(), 'reports/notifications');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, `${Date.now()}-${type}.json`),
+        JSON.stringify({ userId, type, payload }, null, 2)
+      );
+    } else {
+      console.log('Mock notification', { userId, type, payload });
+    }
     return;
   }
 

--- a/services/passport.ts
+++ b/services/passport.ts
@@ -1,11 +1,11 @@
-import * as SecureStore from "expo-secure-store";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { logDataAccess } from "@/packages/db/schemas/DataAccessLog";
 
 const KEY = "passportCountry";
 
 export const getPassportCountry = async (): Promise<string | null> => {
   try {
-    const value = await SecureStore.getItemAsync(KEY);
+    const value = await AsyncStorage.getItem(KEY);
     logDataAccess({
       id: Date.now().toString(),
       actor: "local-user",
@@ -20,7 +20,7 @@ export const getPassportCountry = async (): Promise<string | null> => {
 };
 
 export const setPassportCountry = async (code: string) => {
-  await SecureStore.setItemAsync(KEY, code.toUpperCase());
+  await AsyncStorage.setItem(KEY, code.toUpperCase());
   logDataAccess({
     id: Date.now().toString(),
     actor: "local-user",

--- a/services/userData.ts
+++ b/services/userData.ts
@@ -1,4 +1,4 @@
-import * as SecureStore from "expo-secure-store";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { getDecisionLogs, clearDecisionLogs } from "@/packages/db/schemas/DecisionLog";
 import {
   getDataAccessLogs,
@@ -29,7 +29,7 @@ export const exportUserData = async (userId?: string) => {
 };
 
 export const deleteUserData = async (userId?: string) => {
-  await SecureStore.deleteItemAsync(PASSPORT_KEY);
+  await AsyncStorage.removeItem(PASSPORT_KEY);
   clearDecisionLogs();
   clearDataAccessLogs();
   clearChatLogs();


### PR DESCRIPTION
## Summary
- Avoid bundling Node `fs` and `path` modules in `packages/notify` by dynamically requiring them only in Node environments
- Fallback to console logging when native `fs` is unavailable
- Replace `expo-secure-store` with AsyncStorage for passport and user data helpers to remove unresolved module errors

## Testing
- `npm run lint services/passport.ts services/userData.ts`
- `npm test -- --watchAll=false` *(fails: SyntaxError in react-native/js-polyfills)*
- `npx tsc services/passport.ts services/userData.ts --noEmit --skipLibCheck` *(fails: cannot find Promise/global modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b983f1e2748324bcbd0ba675341721