### PR TITLE
Fix bundling issue from Node fs import in notifications

### DIFF
--- a/packages/notify/index.ts
+++ b/packages/notify/index.ts
@@ -83,16 +83,22 @@ export async function notify(
 
   const useMock = !process.env.EXPO_ACCESS_TOKEN && !process.env.RESEND_API_KEY;
   if (useMock) {
-    if (typeof process !== 'undefined' && (process as any)?.versions?.node) {
-      const fs: any = (eval('require') as any)('fs');
-      const path: any = (eval('require') as any)('path');
-      const dir = path.resolve(process.cwd(), 'reports/notifications');
-      fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(
-        path.join(dir, `${Date.now()}-${type}.json`),
-        JSON.stringify({ userId, type, payload }, null, 2)
-      );
-    } else {
+    try {
+      const isNode =
+        typeof process !== 'undefined' && (process as any)?.versions?.node;
+      if (isNode) {
+        const fs: any = (eval('require') as any)('fs');
+        const path: any = (eval('require') as any)('path');
+        const dir = path.resolve(process.cwd(), 'reports/notifications');
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(
+          path.join(dir, `${Date.now()}-${type}.json`),
+          JSON.stringify({ userId, type, payload }, null, 2)
+        );
+      } else {
+        console.log('Mock notification', { userId, type, payload });
+      }
+    } catch {
       console.log('Mock notification', { userId, type, payload });
     }
     return;


### PR DESCRIPTION
## Summary
- guard Node-specific fs usage in notify mock with runtime checks and fallback

## Testing
- `npm test` *(fails: npm: command not found)*
- `npm run lint` *(fails: npm: command not found)*
- `npm run typecheck` *(fails: npm: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba87948238832487bc5427cc908ed2