### PR TITLE
fix: improve trip generation stability

### DIFF
--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -60,9 +60,14 @@ const Discover = () => {
       );
       const data = await response.json();
 
-      if (data.results && data.results[0] && data.results[0].photos) {
-        const photoReference = data.results[0].photos[0].photo_reference;
-        return `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${photoReference}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`;
+      if (data.results && data.results.length > 0) {
+        const result =
+          data.results.find((r: any) => !r.types?.includes("lodging")) ||
+          data.results[0];
+        const photoReference = result?.photos?.[0]?.photo_reference;
+        if (photoReference) {
+          return `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photo_reference=${photoReference}&key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}`;
+        }
       }
       return DEFAULT_IMAGE_URL;
     } catch (error) {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,15 +15,12 @@ import "../global.css";
 import "react-native-get-random-values";
 import Constants from "expo-constants"; // ⬅️ NEW
 import { CreateTripContext } from "@/context/CreateTripContext";
-import {
-  ItineraryContext,
-  DayPlan,
-  StoredItinerary,
-} from "@/context/ItineraryContext";
+import { ItineraryContext, StoredItinerary } from "@/context/ItineraryContext";
 import HeaderLogo from "@/components/HeaderLogo";
 import { registerTripMonitor } from "@/services/tripMonitor";
 import { initNotifications } from "@/src/notifications";
 import { auth } from "@/config/FirebaseConfig";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
@@ -31,6 +28,25 @@ SplashScreen.preventAutoHideAsync();
 export default function RootLayout() {
   const [tripData, setTripData] = useState<any[]>([]);
   const [itineraries, setItineraries] = useState<StoredItinerary[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem("itineraries");
+        if (stored) {
+          setItineraries(JSON.parse(stored));
+        }
+      } catch (e) {
+        console.error("failed to load itineraries", e);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem("itineraries", JSON.stringify(itineraries)).catch((e) =>
+      console.error("failed to save itineraries", e)
+    );
+  }, [itineraries]);
 
   const addItinerary = (it: StoredItinerary) => {
     setItineraries((prev) => [...prev, it]);

--- a/app/generate-trip.tsx
+++ b/app/generate-trip.tsx
@@ -77,11 +77,32 @@ export default function GenerateTrip() {
 
       // Helper to extract JSON from possible extra text
       const extractJSON = (text: string) => {
-        const match = text.match(/\{[\s\S]*\}/);
-        if (!match) {
+        const start = text.indexOf("{");
+        if (start === -1) {
           throw new Error("Invalid response format");
         }
-        const jsonStr = match[0].replace(/```json|```/gi, "");
+
+        let depth = 0;
+        let end = -1;
+        for (let i = start; i < text.length; i++) {
+          const ch = text[i];
+          if (ch === "{") depth++;
+          if (ch === "}") {
+            depth--;
+            if (depth === 0) {
+              end = i;
+              break;
+            }
+          }
+        }
+
+        if (end === -1) {
+          throw new Error("Invalid response format");
+        }
+
+        const jsonStr = text
+          .slice(start, end + 1)
+          .replace(/```json|```/gi, "");
         try {
           return JSON.parse(jsonStr);
         } catch (_) {


### PR DESCRIPTION
## Summary
- prevent JSON parse errors when generating trips by using balanced extraction
- persist itineraries in AsyncStorage to avoid random loss
- choose better images for places by skipping lodging results

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*
- `npm run lint`
- `npm run typecheck` *(fails: Module '"firebase/auth"' has no exported member 'getReactNativePersistence')*


------
https://chatgpt.com/codex/tasks/task_e_68ba8f2c275883248e6df0ce4de499ba