### PR TITLE
Improve profile, search, and trip organization

### DIFF
--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { View, TextInput, Button, ScrollView, Text } from "react-native";
 import ChatQuickActions from "@/components/ChatQuickActions";
 import { runTravelAgent } from "@/utils/chatAgent";
+import { CreateTripContext } from "@/context/CreateTripContext";
 
 interface Message {
   role: "user" | "agent";
@@ -9,14 +10,25 @@ interface Message {
 }
 
 export default function ChatScreen() {
-  const [messages, setMessages] = useState<Message[]>([]);
+  const { tripData } = useContext(CreateTripContext);
+  const location = tripData.find((t: any) => t.locationInfo)?.locationInfo;
+  const tripId = `${location?.name || "trip"}`;
+  const [messagesByTrip, setMessagesByTrip] = useState<Record<string, Message[]>>({});
   const [input, setInput] = useState("");
+
+  const messages = messagesByTrip[tripId] || [];
 
   const sendPrompt = async (prompt: string) => {
     if (!prompt) return;
-    setMessages((m) => [...m, { role: "user", text: prompt }]);
+    setMessagesByTrip((prev) => ({
+      ...prev,
+      [tripId]: [...messages, { role: "user", text: prompt }],
+    }));
     const reply = await runTravelAgent(prompt);
-    setMessages((m) => [...m, { role: "agent", text: reply }]);
+    setMessagesByTrip((prev) => ({
+      ...prev,
+      [tripId]: [...(prev[tripId] || []), { role: "agent", text: reply }],
+    }));
   };
 
   return (

--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -237,15 +237,17 @@ const Discover = () => {
 
   const loadCheapestFlights = async () => {
     const { origin, destination } = getFlightCodes();
-    const depart = parsedTripPlan?.trip_plan?.flight_details?.departure_date;
-    if (!origin || !destination || !depart) return;
+    if (!origin || !destination) return;
+    const depart =
+      parsedTripPlan?.trip_plan?.flight_details?.departure_date ||
+      new Date().toISOString().split("T")[0];
     setLoadingFlights(true);
     const offers = await flightProvider.search({
       origin,
       destination,
       departDate: depart,
     });
-    setFlightOptions(offers);
+    setFlightOptions(offers.slice(0, 10));
     setLoadingFlights(false);
   };
 
@@ -547,12 +549,10 @@ const Discover = () => {
             <CustomButton
               title="See More Hotels"
               onPress={() => {
-                recordAffiliateClick("hotel");
-                Linking.openURL(
-                  hotelProvider.getSearchUrl({
-                    query: parsedTripPlan.trip_plan.location,
-                  })
-                );
+                router.push({
+                  pathname: "/hotels",
+                  params: { query: parsedTripPlan.trip_plan.location },
+                });
               }}
               bgVariant="outline"
               textVariant="primary"
@@ -597,9 +597,17 @@ const Discover = () => {
             </View>
           </>
         )}
-        <Text className="font-outfit text-text-primary mb-4">
+        <Text className="font-outfit text-text-primary mb-2">
           Tap the + to add a place to your itinerary.
         </Text>
+        {filteredPlaces.length > 0 && (
+          <TouchableOpacity
+            onPress={() => setSelectedPlaces(filteredPlaces)}
+            className="mb-4 self-start"
+          >
+            <Text className="text-primary font-outfit">Select All</Text>
+          </TouchableOpacity>
+        )}
         {filteredPlaces.length ? (
           filteredPlaces.map((place: any, index: number) => {
             const isSelected = selectedPlaces.find(

--- a/app/(tabs)/itineraries.tsx
+++ b/app/(tabs)/itineraries.tsx
@@ -91,7 +91,8 @@ const Itineraries = () => {
         }
       const id = Date.now().toString();
       const title = location?.name || "Trip";
-      const stored: StoredItinerary = { id, title, plan: planData };
+      const tripId = `${title}-${dates?.startDate || id}`;
+      const stored: StoredItinerary = { id, tripId, title, plan: planData };
       addItinerary(stored);
       setCurrentId(id);
     } catch (e) {
@@ -134,6 +135,16 @@ const Itineraries = () => {
     );
   }
 
+  const grouped = itineraries.reduce(
+    (acc: Record<string, StoredItinerary[]>, it) => {
+      const key = it.tripId || "";
+      acc[key] = acc[key] || [];
+      acc[key].push(it);
+      return acc;
+    },
+    {}
+  );
+
   return (
     <SafeAreaView className="flex-1 p-4">
       {itineraries.length === 0 ? (
@@ -141,27 +152,37 @@ const Itineraries = () => {
           <Text className="font-outfit text-text-primary">No itinerary saved.</Text>
         </View>
       ) : (
-        itineraries.map((it) => (
-          <View
-            key={it.id}
-            className="flex-row items-center p-4 mb-3 bg-background rounded-xl border border-primary"
-          >
-            <TouchableOpacity
-              className="flex-row items-center flex-1"
-              onPress={() => setCurrentId(it.id)}
-            >
-              <Ionicons
-                name="map"
-                size={24}
-                color="#9C00FF"
-                style={{ marginRight: 12 }}
-              />
-              <Text className="font-outfit-bold flex-1">{it.title}</Text>
-              <Ionicons name="chevron-forward" size={20} color="#9C00FF" />
-            </TouchableOpacity>
-            <TouchableOpacity onPress={() => handleDelete(it.id)} className="ml-4">
-              <Ionicons name="trash" size={20} color="#EF4444" />
-            </TouchableOpacity>
+        Object.values(grouped).map((group, idx) => (
+          <View key={idx} className="mb-6">
+            <Text className="font-outfit-bold text-lg mb-2">
+              {group[0]?.title}
+            </Text>
+            {group.map((it) => (
+              <View
+                key={it.id}
+                className="flex-row items-center p-4 mb-3 bg-background rounded-xl border border-primary"
+              >
+                <TouchableOpacity
+                  className="flex-row items-center flex-1"
+                  onPress={() => setCurrentId(it.id)}
+                >
+                  <Ionicons
+                    name="map"
+                    size={24}
+                    color="#9C00FF"
+                    style={{ marginRight: 12 }}
+                  />
+                  <Text className="font-outfit-bold flex-1">{it.title}</Text>
+                  <Ionicons name="chevron-forward" size={20} color="#9C00FF" />
+                </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={() => handleDelete(it.id)}
+                  className="ml-4"
+                >
+                  <Ionicons name="trash" size={20} color="#EF4444" />
+                </TouchableOpacity>
+              </View>
+            ))}
           </View>
         ))
       )}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, TouchableOpacity, Switch, Alert } from "react-native";
+import { View, Text, TouchableOpacity, Switch, Alert, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { auth } from "@/config/FirebaseConfig";
 import { router } from "expo-router";
@@ -45,138 +45,140 @@ export default function Profile() {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-background p-6">
-      <Text className="text-3xl font-outfit-bold mb-8">Profile</Text>
+    <SafeAreaView className="flex-1 bg-background">
+      <ScrollView contentContainerStyle={{ padding: 24 }}>
+        <Text className="text-3xl font-outfit-bold mb-8">Profile</Text>
 
-      {/* User Info Section */}
-      <View className="bg-background p-6 rounded-xl mb-8 border border-primary">
-        <View className="flex-row items-center mb-4">
-          <View className="bg-primary p-4 rounded-full">
-            <Ionicons name="person" size={32} color="#F9F5FF" />
+        {/* User Info Section */}
+        <View className="bg-background p-6 rounded-xl mb-8 border border-primary">
+          <View className="flex-row items-center mb-4">
+            <View className="bg-primary p-4 rounded-full">
+              <Ionicons name="person" size={32} color="#F9F5FF" />
+            </View>
+            <View className="ml-4">
+              <Text className="text-xl font-outfit-bold text-text-primary">{user?.email}</Text>
+              <Text className="text-text-primary font-outfit">
+                Member since{" "}
+                {user?.metadata?.creationTime
+                  ? new Date(user.metadata.creationTime).getFullYear()
+                  : ""}
+              </Text>
+            </View>
           </View>
-          <View className="ml-4">
-            <Text className="text-xl font-outfit-bold text-text-primary">{user?.email}</Text>
+        </View>
+
+        {/* Account Settings Section */}
+        <View className="mb-8">
+          <Text className="text-xl font-outfit-bold mb-4">Account Settings</Text>
+
+          <TouchableOpacity className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3">
+            <View className="flex-row items-center">
+              <Ionicons name="mail-outline" size={24} color="#9C00FF" />
+              <Text className="ml-3 font-outfit">Email</Text>
+            </View>
+            <Text className="text-text-primary font-outfit">{user?.email}</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity className="flex-row items-center justify-between bg-background p-4 rounded-xl">
+            <View className="flex-row items-center">
+              <Ionicons name="time-outline" size={24} color="#9C00FF" />
+              <Text className="ml-3 font-outfit">Last Sign In</Text>
+            </View>
             <Text className="text-text-primary font-outfit">
-              Member since{" "}
-              {user?.metadata?.creationTime
-                ? new Date(user.metadata.creationTime).getFullYear()
+              {user?.metadata?.lastSignInTime
+                ? new Date(user.metadata.lastSignInTime).toLocaleDateString()
                 : ""}
             </Text>
-          </View>
+          </TouchableOpacity>
         </View>
-      </View>
 
-      {/* Account Settings Section */}
-      <View className="mb-8">
-        <Text className="text-xl font-outfit-bold mb-4">Account Settings</Text>
-
-        <TouchableOpacity className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3">
-          <View className="flex-row items-center">
-            <Ionicons name="mail-outline" size={24} color="#9C00FF" />
-            <Text className="ml-3 font-outfit">Email</Text>
-          </View>
-          <Text className="text-text-primary font-outfit">{user?.email}</Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity className="flex-row items-center justify-between bg-background p-4 rounded-xl">
-          <View className="flex-row items-center">
-            <Ionicons name="time-outline" size={24} color="#9C00FF" />
-            <Text className="ml-3 font-outfit">Last Sign In</Text>
-          </View>
-          <Text className="text-text-primary font-outfit">
-            {user?.metadata?.lastSignInTime
-              ? new Date(user.metadata.lastSignInTime).toLocaleDateString()
-              : ""}
+        {/* Notification Preferences */}
+        <View className="mb-8">
+          <Text className="text-xl font-outfit-bold mb-4">
+            Notification Preferences
           </Text>
-        </TouchableOpacity>
-      </View>
 
-      {/* Notification Preferences */}
-      <View className="mb-8">
-        <Text className="text-xl font-outfit-bold mb-4">
-          Notification Preferences
-        </Text>
-
-        <View className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3">
-          <View className="flex-row items-center">
-            <Ionicons
-              name="refresh-outline"
-              size={24}
-              color="#9C00FF"
+          <View className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3">
+            <View className="flex-row items-center">
+              <Ionicons
+                name="refresh-outline"
+                size={24}
+                color="#9C00FF"
+              />
+              <Text className="ml-3 font-outfit">Replan Suggestions</Text>
+            </View>
+            <Switch
+              value={prefs.replan}
+              onValueChange={(v) => updatePref("replan", v)}
             />
-            <Text className="ml-3 font-outfit">Replan Suggestions</Text>
           </View>
-          <Switch
-            value={prefs.replan}
-            onValueChange={(v) => updatePref("replan", v)}
-          />
+
+          <View className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3">
+            <View className="flex-row items-center">
+              <Ionicons
+                name="checkmark-done-outline"
+                size={24}
+                color="#9C00FF"
+              />
+              <Text className="ml-3 font-outfit">Booking Confirmed</Text>
+            </View>
+            <Switch
+              value={prefs.booking}
+              onValueChange={(v) => updatePref("booking", v)}
+            />
+          </View>
+
+          <View className="flex-row items-center justify-between bg-background p-4 rounded-xl">
+            <View className="flex-row items-center">
+              <Ionicons
+                name="alert-circle-outline"
+                size={24}
+                color="#9C00FF"
+              />
+              <Text className="ml-3 font-outfit">Disruptions (always on)</Text>
+            </View>
+          </View>
         </View>
 
-        <View className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3">
-          <View className="flex-row items-center">
-            <Ionicons
-              name="checkmark-done-outline"
-              size={24}
-              color="#9C00FF"
-            />
-            <Text className="ml-3 font-outfit">Booking Confirmed</Text>
-          </View>
-          <Switch
-            value={prefs.booking}
-            onValueChange={(v) => updatePref("booking", v)}
-          />
+        {/* Data & Privacy */}
+        <View className="mb-8">
+          <Text className="text-xl font-outfit-bold mb-4">Data & Privacy</Text>
+
+          <TouchableOpacity
+            className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3"
+            onPress={async () => {
+              const data = await exportUserData(user?.uid);
+              Alert.alert("Your Data", JSON.stringify(data));
+            }}
+          >
+            <View className="flex-row items-center">
+              <Ionicons name="download-outline" size={24} color="#9C00FF" />
+              <Text className="ml-3 font-outfit">Export My Data</Text>
+            </View>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            className="flex-row items-center justify-between bg-background p-4 rounded-xl"
+            onPress={async () => {
+              await deleteUserData(user?.uid);
+              Alert.alert("Data Deleted");
+            }}
+          >
+            <View className="flex-row items-center">
+              <Ionicons name="trash-outline" size={24} color="#9C00FF" />
+              <Text className="ml-3 font-outfit">Delete My Data</Text>
+            </View>
+          </TouchableOpacity>
         </View>
 
-        <View className="flex-row items-center justify-between bg-background p-4 rounded-xl">
-          <View className="flex-row items-center">
-            <Ionicons
-              name="alert-circle-outline"
-              size={24}
-              color="#9C00FF"
-            />
-            <Text className="ml-3 font-outfit">Disruptions (always on)</Text>
-          </View>
-        </View>
-      </View>
-
-      {/* Data & Privacy */}
-      <View className="mb-8">
-        <Text className="text-xl font-outfit-bold mb-4">Data & Privacy</Text>
-
-        <TouchableOpacity
-          className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3"
-          onPress={async () => {
-            const data = await exportUserData(user?.uid);
-            Alert.alert("Your Data", JSON.stringify(data));
-          }}
-        >
-          <View className="flex-row items-center">
-            <Ionicons name="download-outline" size={24} color="#9C00FF" />
-            <Text className="ml-3 font-outfit">Export My Data</Text>
-          </View>
-        </TouchableOpacity>
-
-        <TouchableOpacity
-          className="flex-row items-center justify-between bg-background p-4 rounded-xl"
-          onPress={async () => {
-            await deleteUserData(user?.uid);
-            Alert.alert("Data Deleted");
-          }}
-        >
-          <View className="flex-row items-center">
-            <Ionicons name="trash-outline" size={24} color="#9C00FF" />
-            <Text className="ml-3 font-outfit">Delete My Data</Text>
-          </View>
-        </TouchableOpacity>
-      </View>
-
-      {/* Logout Button */}
-      <CustomButton
-        title="Logout"
-        onPress={handleLogout}
-        bgVariant="outline"
-        textVariant="primary"
-      />
+        {/* Logout Button */}
+        <CustomButton
+          title="Logout"
+          onPress={handleLogout}
+          bgVariant="outline"
+          textVariant="primary"
+        />
+      </ScrollView>
     </SafeAreaView>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -34,7 +34,11 @@ export default function RootLayout() {
       try {
         const stored = await AsyncStorage.getItem("itineraries");
         if (stored) {
-          setItineraries(JSON.parse(stored));
+          const parsed: StoredItinerary[] = JSON.parse(stored).map((it: any) => ({
+            tripId: it.tripId || it.title || "trip",
+            ...it,
+          }));
+          setItineraries(parsed);
         }
       } catch (e) {
         console.error("failed to load itineraries", e);

--- a/app/hotels/index.tsx
+++ b/app/hotels/index.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, FlatList, Linking } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useLocalSearchParams } from "expo-router";
+import CustomButton from "@/components/CustomButton";
+import { hotelProvider } from "@/packages/providers/registry";
+import { recordAffiliateClick } from "@/services/affiliate";
+import type { HotelOffer } from "@/packages/providers/types";
+
+export default function HotelList() {
+  const { query } = useLocalSearchParams<{ query?: string }>();
+  const [results, setResults] = useState<HotelOffer[]>([]);
+
+  useEffect(() => {
+    if (query) {
+      hotelProvider
+        .search({ query: String(query) })
+        .then((res) => setResults(res))
+        .catch(() => setResults([]));
+    }
+  }, [query]);
+
+  return (
+    <SafeAreaView className="flex-1 p-4">
+      <Text className="text-2xl font-outfit-bold mb-4">
+        Hotels in {String(query || "")}
+      </Text>
+      <FlatList
+        data={results}
+        keyExtractor={(_, i) => i.toString()}
+        renderItem={({ item }) => (
+          <View className="p-4 mb-4 bg-background rounded-xl border border-primary">
+            <Text className="font-outfit-bold">{item.name}</Text>
+            <Text className="font-outfit text-text-primary">
+              ${item.price}
+            </Text>
+            {item.bookingUrl?.startsWith("http") && (
+              <CustomButton
+                title="Book"
+                onPress={() => {
+                  recordAffiliateClick("hotel");
+                  Linking.openURL(item.bookingUrl);
+                }}
+                className="mt-2"
+              />
+            )}
+          </View>
+        )}
+      />
+    </SafeAreaView>
+  );
+}
+

--- a/context/ItineraryContext.ts
+++ b/context/ItineraryContext.ts
@@ -26,6 +26,8 @@ export interface DayPlan {
 
 export interface StoredItinerary {
   id: string;
+  /** Identifier for the trip this itinerary belongs to */
+  tripId: string;
   title: string;
   plan: DayPlan[];
 }

--- a/packages/providers/default.ts
+++ b/packages/providers/default.ts
@@ -38,14 +38,12 @@ export class DefaultFlightSearchProvider implements FlightSearchProvider {
     } catch {
       // ignore and fall back to mock
     }
-    return [
-      {
-        airline: "Demo Air",
-        flightNumber: "DM100",
-        price: 199,
-        bookingUrl: generateFlightLink(origin, destination, departDate),
-      },
-    ];
+    return Array.from({ length: 10 }).map((_, i) => ({
+      airline: "Demo Air",
+      flightNumber: `DM${100 + i}`,
+      price: 199 + i * 20,
+      bookingUrl: generateFlightLink(origin, destination, departDate),
+    }));
   }
 
   getSearchUrl({

--- a/utils/flexibleDates.ts
+++ b/utils/flexibleDates.ts
@@ -58,5 +58,5 @@ export async function searchCheapestDateRanges(
   }
 
   results.sort((a, b) => a.price - b.price);
-  return results.slice(0, 5);
+  return results.slice(0, 10);
 }


### PR DESCRIPTION
## Summary
- make profile screen scrollable so logout is always visible
- add resilient flexible-date search and hotel listing screen
- group itineraries and chat messages per trip

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba9339ad6083249d577c353a582717