### PR TITLE
feat: improve itinerary flow and currency support

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -48,6 +48,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="itineraries"
         options={{
+          headerShown: false,
           tabBarLabel: "Itineraries",
           tabBarIcon: ({ focused }) => (
             <Ionicons

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useState } from "react";
-import { View, TextInput, Button, ScrollView, Text } from "react-native";
+import { View, TextInput, Button, ScrollView, Text, TouchableOpacity } from "react-native";
 import ChatQuickActions from "@/components/ChatQuickActions";
 import { runTravelAgent } from "@/utils/chatAgent";
-import { CreateTripContext } from "@/context/CreateTripContext";
+import { ItineraryContext } from "@/context/ItineraryContext";
 
 interface Message {
   role: "user" | "agent";
@@ -10,11 +10,35 @@ interface Message {
 }
 
 export default function ChatScreen() {
-  const { tripData } = useContext(CreateTripContext);
-  const location = tripData.find((t: any) => t.locationInfo)?.locationInfo;
-  const tripId = `${location?.name || "trip"}`;
+  const { itineraries } = useContext(ItineraryContext);
+  const [tripId, setTripId] = useState<string | null>(
+    itineraries[0]?.tripId || null
+  );
   const [messagesByTrip, setMessagesByTrip] = useState<Record<string, Message[]>>({});
   const [input, setInput] = useState("");
+
+  if (!tripId) {
+    return (
+      <View className="flex-1 p-4">
+        <ScrollView>
+          {itineraries.map((it) => (
+            <TouchableOpacity
+              key={it.tripId}
+              className="p-4 mb-3 bg-background rounded-xl border border-primary"
+              onPress={() => setTripId(it.tripId)}
+            >
+              <Text className="font-outfit">{it.title}</Text>
+            </TouchableOpacity>
+          ))}
+          {itineraries.length === 0 && (
+            <Text className="font-outfit text-text-primary">
+              No trips available.
+            </Text>
+          )}
+        </ScrollView>
+      </View>
+    );
+  }
 
   const messages = messagesByTrip[tripId] || [];
 

--- a/app/(tabs)/discover.tsx
+++ b/app/(tabs)/discover.tsx
@@ -686,6 +686,13 @@ const Discover = () => {
     {selectedPlaces.length > 0 && (
       <View className="absolute bottom-4 left-0 right-0 px-6">
         <CustomButton
+          title="Deselect All"
+          onPress={() => setSelectedPlaces([])}
+          className="mb-2"
+          bgVariant="outline"
+          textVariant="primary"
+        />
+        <CustomButton
           title="Generate Itinerary"
           onPress={() =>
             router.push({

--- a/app/(tabs)/itineraries.tsx
+++ b/app/(tabs)/itineraries.tsx
@@ -42,7 +42,8 @@ const Itineraries = () => {
       const session = startChatSession([{ role: "user", parts: [{ text: prompt }] }]);
       const result = await session.sendMessage(prompt);
       const raw = await result.response.text();
-        const json = JSON.parse(raw);
+        const jsonStr = (raw.match(/\{[\s\S]*\}/) || ["{}"])[0];
+        const json = JSON.parse(jsonStr);
         const rawPlan: any[] = json.itinerary || [];
         let planData: DayPlan[] = rawPlan.map((d) => ({
           ...d,

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -10,6 +10,7 @@ import {
   getNotificationPreferences,
   setNotificationPreferences,
 } from "@/packages/notify";
+import { useCurrency, Currency } from "@/context/CurrencyContext";
 
 export default function Profile() {
   const user = auth?.currentUser;
@@ -18,6 +19,8 @@ export default function Profile() {
     replan: true,
     booking: true,
   }));
+  const { currency, setCurrency } = useCurrency();
+  const currencies: Currency[] = ["USD", "EUR", "GBP"];
 
   useEffect(() => {
     if (user?.uid) {
@@ -138,6 +141,23 @@ export default function Profile() {
               <Text className="ml-3 font-outfit">Disruptions (always on)</Text>
             </View>
           </View>
+        </View>
+
+        {/* Currency Preference */}
+        <View className="mb-8">
+          <Text className="text-xl font-outfit-bold mb-4">Currency</Text>
+          {currencies.map((cur) => (
+            <TouchableOpacity
+              key={cur}
+              className="flex-row items-center justify-between bg-background p-4 rounded-xl mb-3"
+              onPress={() => setCurrency(cur)}
+            >
+              <Text className="font-outfit">{cur}</Text>
+              {currency === cur && (
+                <Ionicons name="checkmark" size={20} color="#9C00FF" />
+              )}
+            </TouchableOpacity>
+          ))}
         </View>
 
         {/* Data & Privacy */}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,6 +21,7 @@ import { registerTripMonitor } from "@/services/tripMonitor";
 import { initNotifications } from "@/src/notifications";
 import { auth } from "@/config/FirebaseConfig";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { CurrencyProvider } from "@/context/CurrencyContext";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
@@ -98,7 +99,7 @@ export default function RootLayout() {
   }
 
   return (
-    <>
+    <CurrencyProvider>
       <CreateTripContext.Provider value={{ tripData, setTripData }}>
         <ItineraryContext.Provider value={{ itineraries, addItinerary, removeItinerary }}>
           <StatusBar style="dark" />
@@ -114,6 +115,6 @@ export default function RootLayout() {
           </Stack>
         </ItineraryContext.Provider>
       </CreateTripContext.Provider>
-    </>
+    </CurrencyProvider>
   );
 }

--- a/app/hotels/index.tsx
+++ b/app/hotels/index.tsx
@@ -1,14 +1,18 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, FlatList, Linking } from "react-native";
+import { View, Text, FlatList, Linking, TouchableOpacity } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import Ionicons from "@expo/vector-icons/Ionicons";
 import CustomButton from "@/components/CustomButton";
 import { hotelProvider } from "@/packages/providers/registry";
 import { recordAffiliateClick } from "@/services/affiliate";
 import type { HotelOffer } from "@/packages/providers/types";
+import { useCurrency } from "@/context/CurrencyContext";
 
 export default function HotelList() {
   const { query } = useLocalSearchParams<{ query?: string }>();
+  const router = useRouter();
+  const { format } = useCurrency();
   const [results, setResults] = useState<HotelOffer[]>([]);
 
   useEffect(() => {
@@ -22,31 +26,43 @@ export default function HotelList() {
 
   return (
     <SafeAreaView className="flex-1 p-4">
+      <TouchableOpacity className="mb-4" onPress={() => router.back()}>
+        <Ionicons name="arrow-back" size={24} color="#1E1B4B" />
+      </TouchableOpacity>
       <Text className="text-2xl font-outfit-bold mb-4">
         Hotels in {String(query || "")}
       </Text>
-      <FlatList
-        data={results}
-        keyExtractor={(_, i) => i.toString()}
-        renderItem={({ item }) => (
-          <View className="p-4 mb-4 bg-background rounded-xl border border-primary">
-            <Text className="font-outfit-bold">{item.name}</Text>
-            <Text className="font-outfit text-text-primary">
-              ${item.price}
-            </Text>
-            {item.bookingUrl?.startsWith("http") && (
-              <CustomButton
-                title="Book"
-                onPress={() => {
-                  recordAffiliateClick("hotel");
-                  Linking.openURL(item.bookingUrl);
-                }}
-                className="mt-2"
-              />
-            )}
-          </View>
-        )}
-      />
+      {results.length === 0 ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="font-outfit text-text-primary mb-4">
+            No hotels found.
+          </Text>
+          <CustomButton title="Go Back" onPress={() => router.back()} />
+        </View>
+      ) : (
+        <FlatList
+          data={results}
+          keyExtractor={(_, i) => i.toString()}
+          renderItem={({ item }) => (
+            <View className="p-4 mb-4 bg-background rounded-xl border border-primary">
+              <Text className="font-outfit-bold">{item.name}</Text>
+              <Text className="font-outfit text-text-primary">
+                {format(Number(item.price))}
+              </Text>
+              {item.bookingUrl?.startsWith("http") && (
+                <CustomButton
+                  title="Book"
+                  onPress={() => {
+                    recordAffiliateClick("hotel");
+                    Linking.openURL(item.bookingUrl);
+                  }}
+                  className="mt-2"
+                />
+              )}
+            </View>
+          )}
+        />
+      )}
     </SafeAreaView>
   );
 }

--- a/context/CurrencyContext.tsx
+++ b/context/CurrencyContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const rates = { USD: 1, EUR: 0.92, GBP: 0.79 } as const;
+export type Currency = keyof typeof rates;
+
+interface CurrencyContextValue {
+  currency: Currency;
+  setCurrency: (c: Currency) => void;
+  format: (value: number) => string;
+}
+
+const CurrencyContext = createContext<CurrencyContextValue>({
+  currency: 'USD',
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  setCurrency: () => {},
+  format: (v: number) => `$${v.toFixed(2)}`,
+});
+
+export const CurrencyProvider = ({ children }: { children: React.ReactNode }) => {
+  const [currency, setCurrency] = useState<Currency>('USD');
+
+  const format = (value: number) => {
+    const rate = rates[currency] ?? 1;
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+    }).format(value * rate);
+  };
+
+  return (
+    <CurrencyContext.Provider value={{ currency, setCurrency, format }}>
+      {children}
+    </CurrencyContext.Provider>
+  );
+};
+
+export const useCurrency = () => useContext(CurrencyContext);
+

--- a/utils/flexibleDates.ts
+++ b/utils/flexibleDates.ts
@@ -20,43 +20,43 @@ export async function searchCheapestDateRanges(
   const [minDays, maxDays] = durationRange;
   const tpToken = process.env.EXPO_PUBLIC_TRAVELPAYOUTS_TOKEN;
   const today = new Date();
-  const results: FlexibleDateRange[] = [];
+  const tasks: Promise<FlexibleDateRange>[] = [];
 
-  // Search over the next 30 days for the best prices
   for (let offset = 0; offset < 30; offset++) {
     const start = new Date(today.getTime() + offset * 86400000);
     for (let len = minDays; len <= maxDays; len++) {
       const end = new Date(start.getTime() + len * 86400000);
-      let price = Number.POSITIVE_INFINITY;
-
-      if (tpToken) {
-        try {
-          const depart = format(start, 'yyyy-MM-dd');
-          const ret = format(end, 'yyyy-MM-dd');
-          const res = await fetch(
-            `https://api.travelpayouts.com/v2/prices/latest?origin=${origin}&destination=${destination}&depart_date=${depart}&return_date=${ret}&token=${tpToken}&currency=usd`
-          );
-          const json = await res.json();
-          const flight = json.data?.[0];
-          if (flight?.value) price = flight.value;
-        } catch (e) {
-          console.error('flexible date search failed', e);
-        }
-      }
-
-      // Fallback random price when API isn't available
-      if (!isFinite(price)) {
-        price = Math.round(50 + Math.random() * 450);
-      }
-
-      results.push({
-        startDate: start.toISOString().split('T')[0],
-        endDate: end.toISOString().split('T')[0],
-        price,
-      });
+      tasks.push(
+        (async () => {
+          let price = Number.POSITIVE_INFINITY;
+          if (tpToken) {
+            try {
+              const depart = format(start, 'yyyy-MM-dd');
+              const ret = format(end, 'yyyy-MM-dd');
+              const res = await fetch(
+                `https://api.travelpayouts.com/v2/prices/latest?origin=${origin}&destination=${destination}&depart_date=${depart}&return_date=${ret}&token=${tpToken}&currency=usd`
+              );
+              const json = await res.json();
+              const flight = json.data?.[0];
+              if (flight?.value) price = flight.value;
+            } catch (e) {
+              console.error('flexible date search failed', e);
+            }
+          }
+          if (!isFinite(price)) {
+            price = Math.round(50 + Math.random() * 450);
+          }
+          return {
+            startDate: start.toISOString().split('T')[0],
+            endDate: end.toISOString().split('T')[0],
+            price,
+          } as FlexibleDateRange;
+        })()
+      );
     }
   }
 
+  const results = await Promise.all(tasks);
   results.sort((a, b) => a.price - b.price);
   return results.slice(0, 10);
 }


### PR DESCRIPTION
## Summary
- add global currency context and profile selection
- fix itinerary generation JSON parsing and hide default tab header
- improve hotel list navigation and allow deselecting all places
- optimise flexible date search and enable trip selection in chat

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ba97b6d4008324819fbc72bda2392e