### PR TITLE
feat: enable chat for trips without itineraries

### DIFF
--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -1,12 +1,26 @@
-import React, { useContext, useState } from "react";
-import { View, TextInput, Button, ScrollView, Text, TouchableOpacity } from "react-native";
+import React, { useContext, useEffect, useState } from "react";
+import {
+  View,
+  TextInput,
+  Button,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+} from "react-native";
+import { collection, getDocs } from "firebase/firestore";
 import ChatQuickActions from "@/components/ChatQuickActions";
 import { runTravelAgent } from "@/utils/chatAgent";
 import { ItineraryContext } from "@/context/ItineraryContext";
+import { auth, db } from "@/config/FirebaseConfig";
 
 interface Message {
   role: "user" | "agent";
   text: string;
+}
+
+interface TripOption {
+  tripId: string;
+  title: string;
 }
 
 export default function ChatScreen() {
@@ -14,24 +28,54 @@ export default function ChatScreen() {
   const [tripId, setTripId] = useState<string | null>(null);
   const [messagesByTrip, setMessagesByTrip] = useState<Record<string, Message[]>>({});
   const [input, setInput] = useState("");
+  const [tripOptions, setTripOptions] = useState<TripOption[]>([]);
+
+  // merge itineraries into trip options
+  useEffect(() => {
+    setTripOptions((prev) => {
+      const map = new Map(prev.map((t) => [t.tripId, t]));
+      itineraries.forEach((it) => {
+        map.set(it.tripId, { tripId: it.tripId, title: it.title });
+      });
+      return Array.from(map.values());
+    });
+  }, [itineraries]);
+
+  // fetch trips from Firestore so chat works even without itineraries
+  useEffect(() => {
+    const fetchTrips = async () => {
+      const user = auth?.currentUser;
+      if (!db || !user) return;
+      const tripCollection = collection(db, "UserTrips", user.uid, "trips");
+      const snapshot = await getDocs(tripCollection);
+      setTripOptions((prev) => {
+        const map = new Map(prev.map((t) => [t.tripId, t]));
+        snapshot.forEach((docSnap) => {
+          const data = docSnap.data() as any;
+          const title = data.tripPlan?.trip_plan?.location || "Trip";
+          map.set(docSnap.id, { tripId: docSnap.id, title });
+        });
+        return Array.from(map.values());
+      });
+    };
+    fetchTrips();
+  }, []);
 
   if (!tripId) {
     return (
       <View className="flex-1 p-4">
         <ScrollView>
-          {itineraries.map((it) => (
+          {tripOptions.map((t) => (
             <TouchableOpacity
-              key={it.tripId}
+              key={t.tripId}
               className="p-4 mb-3 bg-background rounded-xl border border-primary"
-              onPress={() => setTripId(it.tripId)}
+              onPress={() => setTripId(t.tripId)}
             >
-              <Text className="font-outfit">{it.title}</Text>
+              <Text className="font-outfit">{t.title}</Text>
             </TouchableOpacity>
           ))}
-          {itineraries.length === 0 && (
-            <Text className="font-outfit text-text-primary">
-              No trips available.
-            </Text>
+          {tripOptions.length === 0 && (
+            <Text className="font-outfit text-text-primary">No trips available.</Text>
           )}
         </ScrollView>
       </View>
@@ -47,24 +91,40 @@ export default function ChatScreen() {
       ...prev,
       [currentTripId]: [...messages, { role: "user", text: prompt }],
     }));
-    const reply = await runTravelAgent(prompt, currentTripId);
-    setMessagesByTrip((prev) => ({
-      ...prev,
-      [currentTripId]: [...(prev[currentTripId] || []), { role: "agent", text: reply }],
-    }));
+    try {
+      const reply = await runTravelAgent(prompt, currentTripId);
+      setMessagesByTrip((prev) => ({
+        ...prev,
+        [currentTripId]: [
+          ...(prev[currentTripId] || []),
+          { role: "agent", text: reply || "" },
+        ],
+      }));
+    } catch (e) {
+      setMessagesByTrip((prev) => ({
+        ...prev,
+        [currentTripId]: [
+          ...(prev[currentTripId] || []),
+          { role: "agent", text: "Sorry, something went wrong." },
+        ],
+      }));
+    }
   };
 
   return (
     <View className="flex-1 p-4">
       <View className="flex-row justify-between mb-2">
-        <Text className="font-outfit text-lg">{
-          itineraries.find((it) => it.tripId === tripId)?.title || ""
-        }</Text>
+        <Text className="font-outfit text-lg">
+          {tripOptions.find((t) => t.tripId === tripId)?.title || ""}
+        </Text>
         <Button title="Change Trip" onPress={() => setTripId(null)} />
       </View>
       <ScrollView className="flex-1">
         {messages.map((m, idx) => (
-          <Text key={idx} className={m.role === "user" ? "text-right" : "text-left"}>
+          <Text
+            key={idx}
+            className={m.role === "user" ? "text-right" : "text-left"}
+          >
             {m.text}
           </Text>
         ))}
@@ -88,3 +148,4 @@ export default function ChatScreen() {
     </View>
   );
 }
+


### PR DESCRIPTION
## Summary
- allow chat to list trips fetched from Firestore so users can chat without prebuilt itineraries
- handle chat agent errors and display a fallback message

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*
- `npm run lint`
- `npm run typecheck` *(fails: Module '"firebase/auth"' has no exported member 'getReactNativePersistence')*


------
https://chatgpt.com/codex/tasks/task_e_68baaeddcf288324a6c3bc954695d021