### PR TITLE
fix: resolve firebase auth import

### DIFF
--- a/config/FirebaseConfig.ts
+++ b/config/FirebaseConfig.ts
@@ -4,9 +4,11 @@ import { Platform } from "react-native";
 import Constants from "expo-constants";
 import { initializeApp, FirebaseApp } from "firebase/app";
 import { getAuth, initializeAuth, Auth } from "firebase/auth";
-import { getReactNativePersistence } from "firebase/auth/react-native";
+import * as AuthModule from "firebase/auth";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { getFirestore, Firestore } from "firebase/firestore";
+
+const getReactNativePersistence = (AuthModule as any).getReactNativePersistence as (storage: typeof AsyncStorage) => any;
 
 // Pull your values from app.config.js → extra (or .env → EXPO_PUBLIC_…)
 const {


### PR DESCRIPTION
## Summary
- import firebase React Native persistence via main auth entrypoint

## Testing
- `npm test -- --watchAll=false` *(fails: Unexpected identifier 'ErrorHandler')*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bac1d45d5083249185d73b4165fe89