### PR TITLE
Improve chat error reporting

### DIFF
--- a/context/ChatContext.tsx
+++ b/context/ChatContext.tsx
@@ -53,7 +53,8 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
         updateLastAssistantMessage(tripId, m => ({ ...m, content: m.content + token }));
       });
     } catch (e) {
-      updateLastAssistantMessage(tripId, m => ({ ...m, content: 'Sorry, something went wrong.' }));
+      const message = e instanceof Error ? e.message : 'Sorry, something went wrong.';
+      updateLastAssistantMessage(tripId, m => ({ ...m, content: message }));
     }
   };
 


### PR DESCRIPTION
## Summary
- show underlying error message instead of generic failure in chat context

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bac9003d3c83248755b22f51fb729d