### PR TITLE
feat: scaffold server and settings

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -73,6 +73,19 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="settings"
+        options={{
+          tabBarLabel: "Settings",
+          tabBarIcon: ({ focused }) => (
+            <Ionicons
+              name="settings-sharp"
+              size={24}
+              color={focused ? "#9C00FF" : "#1E1B4B"}
+            />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="profile"
         options={{
           tabBarLabel: "Profile",

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import {
   View,
   TextInput,
+  Switch,
   Button,
   ScrollView,
   Text,
@@ -21,6 +22,7 @@ interface TripOption {
 export default function ChatScreen() {
   const { itineraries } = useContext(ItineraryContext);
   const { messagesByTrip, sendMessage } = useChat();
+  const [tripMode, setTripMode] = useState(true);
   const [tripId, setTripId] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const [tripOptions, setTripOptions] = useState<TripOption[]>([]);
@@ -85,13 +87,15 @@ export default function ChatScreen() {
     await sendMessage(prompt, currentTripId);
   };
 
-
   return (
     <View className="flex-1 p-4">
       <View className="flex-row justify-between mb-2">
-        <Text className="font-outfit text-lg">
-          {tripOptions.find((t) => t.tripId === tripId)?.title || ""}
-        </Text>
+        <View className="flex-row items-center">
+          <Text className="font-outfit text-lg">
+            {tripOptions.find((t) => t.tripId === tripId)?.title || ""}
+          </Text>
+          <Switch className="ml-2" value={tripMode} onValueChange={setTripMode} />
+        </View>
         <Button title="Change Trip" onPress={() => setTripId(null)} />
       </View>
       <ScrollView className="flex-1">
@@ -123,4 +127,3 @@ export default function ChatScreen() {
     </View>
   );
 }
-

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { View, Text, Switch, TextInput, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function Settings() {
+  const [handsOff, setHandsOff] = useState(false);
+  const [tripLimit, setTripLimit] = useState('');
+  const [bookingLimit, setBookingLimit] = useState('');
+
+  return (
+    <SafeAreaView className="flex-1 bg-background">
+      <ScrollView contentContainerStyle={{ padding: 24 }}>
+        <Text className="text-3xl font-outfit-bold mb-8">Settings</Text>
+
+        <View className="flex-row items-center justify-between mb-6">
+          <Text className="text-lg font-outfit">Hands-off Mode</Text>
+          <Switch value={handsOff} onValueChange={setHandsOff} />
+        </View>
+
+        <View className="mb-6">
+          <Text className="font-outfit mb-2">Trip Budget Limit</Text>
+          <TextInput
+            value={tripLimit}
+            onChangeText={setTripLimit}
+            placeholder="$"
+            keyboardType="numeric"
+            className="border p-2 rounded"
+          />
+        </View>
+
+        <View className="mb-6">
+          <Text className="font-outfit mb-2">Per Booking Limit</Text>
+          <TextInput
+            value={bookingLimit}
+            onChangeText={setBookingLimit}
+            placeholder="$"
+            keyboardType="numeric"
+            className="border p-2 rounded"
+          />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "sim:weather": "node --loader ts-node/esm tools/simulate/weather.ts",
     "test:e2e:web": "playwright test e2e/web",
     "test:e2e:mobile": "echo 'mobile e2e skipped'",
-    "test:a11y": "node tools/axe.js"
+    "test:a11y": "node tools/axe.js",
+    "server": "ts-node server/index.ts"
   },
   "jest": {
     "preset": "jest-expo",
@@ -67,7 +68,9 @@
     "react-native-web": "^0.20.0",
     "setimmediate": "^1.0.5",
     "stripe": "^18.5.0",
-    "tailwindcss": "^3.4.14"
+    "tailwindcss": "^3.4.14",
+    "express": "^4.19.2",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/server/agent/policies.ts
+++ b/server/agent/policies.ts
@@ -1,0 +1,13 @@
+export interface HandsOffPolicy {
+  tripBudget: number;
+  bookingLimit: number;
+  preferredAirlines: string[];
+  bannedAirlines: string[];
+}
+
+export const defaultPolicy: HandsOffPolicy = {
+  tripBudget: 0,
+  bookingLimit: 0,
+  preferredAirlines: [],
+  bannedAirlines: [],
+};

--- a/server/agent/runtime.ts
+++ b/server/agent/runtime.ts
@@ -1,0 +1,9 @@
+// Minimal orchestrator placeholder using OpenAI function calling
+import type { ChatMessage } from '../../src/shared/chat/types';
+
+export async function runAgent(messages: ChatMessage[]): Promise<string> {
+  // In a full implementation this would call the OpenAI API with function calling
+  // and invoke domain specific tools. For now we just echo the last user message.
+  const last = messages.reverse().find(m => m.role === 'user');
+  return last ? `Agent: ${last.content}` : 'Agent ready';
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,86 @@
+import express from 'express';
+import http from 'http';
+import { WebSocketServer, WebSocket } from 'ws';
+
+// simple in-memory storage for demo purposes
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const conversations: Record<string, Message[]> = {};
+
+const app = express();
+app.use(express.json());
+
+// enqueue user message and simulate LLM processing
+app.post('/api/chat/:tripId/send', (req, res) => {
+  const { tripId } = req.params;
+  const { message } = req.body as { message?: string };
+  if (!message) {
+    return res.status(400).json({ error: 'message required' });
+  }
+  const convo = conversations[tripId] || (conversations[tripId] = []);
+  convo.push({ role: 'user', content: message });
+
+  // simulate LLM response
+  setTimeout(() => {
+    const reply = `Echo: ${message}`;
+    convo.push({ role: 'assistant', content: reply });
+    broadcast(tripId, reply);
+  }, 250);
+
+  res.json({ status: 'queued' });
+});
+
+// simple websocket handler for streaming assistant replies
+const server = http.createServer(app);
+const wss = new WebSocketServer({ noServer: true });
+const sockets: Record<string, Set<WebSocket>> = {};
+
+server.on('upgrade', (req, socket, head) => {
+  const url = new URL(req.url ?? '', 'http://localhost');
+  if (url.pathname.startsWith('/api/chat/') && url.pathname.endsWith('/ws')) {
+    const parts = url.pathname.split('/');
+    const tripId = parts[3];
+    wss.handleUpgrade(req, socket as any, head, (ws) => {
+      const set = sockets[tripId] || (sockets[tripId] = new Set());
+      set.add(ws);
+      ws.on('close', () => set.delete(ws));
+    });
+  }
+});
+
+function broadcast(tripId: string, text: string) {
+  const set = sockets[tripId];
+  if (!set) return;
+  for (const ws of set) {
+    ws.send(JSON.stringify({ type: 'token', value: text }));
+  }
+}
+
+// mock concierge checkout using Stripe
+app.post('/api/concierge/checkout', (_req, res) => {
+  if (!process.env.STRIPE_KEY) {
+    return res.json({ url: 'https://example.com/mock-checkout' });
+  }
+  // real Stripe integration would go here
+  res.json({ url: 'https://example.com/checkout' });
+});
+
+// mock Expo push notifications
+app.post('/api/notify/push', (req, res) => {
+  if (!process.env.EXPO_TOKEN) {
+    console.log('Mock push notification:', req.body);
+    return res.json({ mock: true });
+  }
+  // real Expo push notification would go here
+  res.json({ sent: true });
+});
+
+const port = process.env.PORT || 3001;
+server.listen(port, () => {
+  console.log(`server listening on ${port}`);
+});
+
+export default server;

--- a/server/jobs/flightWatcher.ts
+++ b/server/jobs/flightWatcher.ts
@@ -1,0 +1,7 @@
+// periodically checks flight status and triggers replanning
+export function startFlightWatcher() {
+  setInterval(() => {
+    // TODO: connect to flight status API
+    console.log('flight watcher tick');
+  }, 60_000);
+}

--- a/server/jobs/weatherWatcher.ts
+++ b/server/jobs/weatherWatcher.ts
@@ -1,0 +1,7 @@
+// watches weather forecasts and suggests itinerary changes
+export function startWeatherWatcher() {
+  setInterval(() => {
+    // TODO: call weather tool and notify users
+    console.log('weather watcher tick');
+  }, 60_000);
+}

--- a/server/tools/weather.ts
+++ b/server/tools/weather.ts
@@ -1,0 +1,12 @@
+export interface WeatherResult {
+  forecast: string;
+  tempC: number;
+}
+
+export async function getWeather(location: string): Promise<WeatherResult> {
+  if (process.env.USE_MOCK_PROVIDERS) {
+    return { forecast: 'sunny', tempC: 25 };
+  }
+  // real weather provider integration would go here
+  return { forecast: 'unknown', tempC: 0 };
+}

--- a/src/shared/chat/types.ts
+++ b/src/shared/chat/types.ts
@@ -1,0 +1,17 @@
+export interface ChatMessage {
+  id?: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+export interface ToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface TravelerProfile {
+  id: string;
+  name: string;
+  budget: number;
+  preferences?: Record<string, unknown>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "context/**/*",
     "services/**/*",
     "src/**/*",
+    "server/**/*",
     "utils/**/*",
     "packages/impact/**/*",
     "packages/providers/**/*",


### PR DESCRIPTION
## Summary
- scaffold Express/WebSocket server with chat, checkout, and notification endpoints
- share chat types between client and server
- add Trip Mode toggle and settings screen for hands-off budgets

## Testing
- `CI=1 npm test` *(fails: Jest encountered an unexpected token in react-native js-polyfills)*

------
https://chatgpt.com/codex/tasks/task_e_68bacfad3f5083248c05083a610324a8