### PR TITLE
feat: add basic theme system and navigation

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,9 +1,8 @@
 import { Tabs } from "expo-router";
 import React from "react";
 import { Ionicons } from "@expo/vector-icons";
-import MaterialIcons from "@expo/vector-icons/MaterialIcons";
-import FontAwesome from "@expo/vector-icons/FontAwesome";
 import HeaderLogo from "@/components/HeaderLogo";
+import colors from "@/src/theme/colors";
 
 export default function TabLayout() {
   return (
@@ -11,63 +10,62 @@ export default function TabLayout() {
       screenOptions={{
         headerShown: true,
         headerTitle: () => <HeaderLogo />,
-        tabBarActiveTintColor: "#9C00FF",
-        tabBarInactiveTintColor: "#1E1B4B",
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.textSecondary,
         tabBarLabelStyle: {
-          fontFamily: "outfit-medium",
+          fontFamily: 'Inter',
           fontSize: 12,
         },
       }}
     >
       <Tabs.Screen
-        name="mytrip"
+        name="index"
         options={{
-          tabBarLabel: "My Trips",
+          tabBarLabel: 'Home',
           tabBarIcon: ({ focused }) => (
             <Ionicons
-              name="location-sharp"
+              name="home"
               size={24}
-              color={focused ? "#9C00FF" : "#1E1B4B"}
+              color={focused ? colors.primary : colors.textSecondary}
             />
           ),
         }}
       />
       <Tabs.Screen
-        name="discover"
+        name="plan"
         options={{
-          tabBarLabel: "Discover",
-          tabBarIcon: ({ focused }) => (
-            <MaterialIcons
-              name="travel-explore"
-              size={24}
-              color={focused ? "#9C00FF" : "#1E1B4B"}
-            />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="itineraries"
-        options={{
-          headerShown: false,
-          tabBarLabel: "Itineraries",
+          tabBarLabel: 'Plan',
           tabBarIcon: ({ focused }) => (
             <Ionicons
               name="calendar"
               size={24}
-              color={focused ? "#9C00FF" : "#1E1B4B"}
+              color={focused ? colors.primary : colors.textSecondary}
             />
           ),
         }}
       />
       <Tabs.Screen
-        name="chat"
+        name="nearby"
         options={{
-          tabBarLabel: "Chat",
+          tabBarLabel: 'Nearby',
           tabBarIcon: ({ focused }) => (
             <Ionicons
-              name="chatbubbles"
+              name="map"
               size={24}
-              color={focused ? "#9C00FF" : "#1E1B4B"}
+              color={focused ? colors.primary : colors.textSecondary}
+            />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="guides"
+        options={{
+          tabBarLabel: 'Guides',
+          tabBarIcon: ({ focused }) => (
+            <Ionicons
+              name="book"
+              size={24}
+              color={focused ? colors.primary : colors.textSecondary}
             />
           ),
         }}
@@ -75,25 +73,12 @@ export default function TabLayout() {
       <Tabs.Screen
         name="settings"
         options={{
-          tabBarLabel: "Settings",
+          tabBarLabel: 'Settings',
           tabBarIcon: ({ focused }) => (
             <Ionicons
               name="settings-sharp"
               size={24}
-              color={focused ? "#9C00FF" : "#1E1B4B"}
-            />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="profile"
-        options={{
-          tabBarLabel: "Profile",
-          tabBarIcon: ({ focused }) => (
-            <FontAwesome
-              name="user-o"
-              size={21}
-              color={focused ? "#9C00FF" : "#1E1B4B"}
+              color={focused ? colors.primary : colors.textSecondary}
             />
           ),
         }}

--- a/app/(tabs)/guides.tsx
+++ b/app/(tabs)/guides.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View, Text, ScrollView } from 'react-native';
+
+export default function Guides() {
+  return (
+    <ScrollView className="flex-1 bg-surface p-4">
+      <Text className="text-heading text-textPrimary font-bold mb-4">Local Guides</Text>
+      <View className="bg-cardBg rounded-lg shadow-md p-4 mb-4">
+        <Text className="text-textSecondary">No tips yet</Text>
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text, ImageBackground, TouchableOpacity } from 'react-native';
+import { Link } from 'expo-router';
+
+export default function Home() {
+  return (
+    <ImageBackground
+      source={require('@/assets/images/wishwander-sign.jpg')}
+      className="flex-1"
+      resizeMode="cover"
+    >
+      <View className="flex-1 bg-black/40 items-center justify-center p-4">
+        <Text className="text-heading text-cardBg font-bold mb-6 text-center">
+          Your AI travel companion
+        </Text>
+        <Link href="/(tabs)/plan" asChild>
+          <TouchableOpacity className="bg-primary px-6 py-3 rounded-full mb-4">
+            <Text className="text-cardBg text-subtitle">Start Planning</Text>
+          </TouchableOpacity>
+        </Link>
+        <Link href="/(tabs)/nearby" asChild>
+          <TouchableOpacity className="bg-accent px-6 py-3 rounded-full">
+            <Text className="text-cardBg text-subtitle">Explore Nearby</Text>
+          </TouchableOpacity>
+        </Link>
+      </View>
+    </ImageBackground>
+  );
+}

--- a/app/(tabs)/nearby.tsx
+++ b/app/(tabs)/nearby.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function Nearby() {
+  return (
+    <View className="flex-1 bg-surface items-center justify-center">
+      <Text className="text-textPrimary">Map coming soon...</Text>
+    </View>
+  );
+}

--- a/app/(tabs)/plan.tsx
+++ b/app/(tabs)/plan.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, ScrollView, TouchableOpacity } from 'react-native';
+
+export default function Plan() {
+  return (
+    <ScrollView className="flex-1 bg-surface p-4">
+      <Text className="text-heading text-textPrimary font-bold mb-4">Upcoming Trip</Text>
+      <View className="bg-cardBg rounded-lg shadow-md p-4 mb-4">
+        <Text className="text-textSecondary">No trips yet</Text>
+      </View>
+      <View className="flex-row justify-between">
+        <TouchableOpacity className="bg-primary px-4 py-2 rounded-lg">
+          <Text className="text-cardBg text-body">Add activity</Text>
+        </TouchableOpacity>
+        <TouchableOpacity className="bg-accent px-4 py-2 rounded-lg">
+          <Text className="text-cardBg text-body">Replan</Text>
+        </TouchableOpacity>
+        <TouchableOpacity className="bg-primary px-4 py-2 rounded-lg">
+          <Text className="text-cardBg text-body">Share</Text>
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,41 +1,48 @@
 import React, { useState } from 'react';
 import { View, Text, Switch, TextInput, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useThemeContext } from '@/context/ThemeContext';
 
 export default function Settings() {
+  const { scheme, toggle } = useThemeContext();
   const [handsOff, setHandsOff] = useState(false);
   const [tripLimit, setTripLimit] = useState('');
   const [bookingLimit, setBookingLimit] = useState('');
 
   return (
-    <SafeAreaView className="flex-1 bg-background">
+    <SafeAreaView className="flex-1 bg-surface">
       <ScrollView contentContainerStyle={{ padding: 24 }}>
-        <Text className="text-3xl font-outfit-bold mb-8">Settings</Text>
+        <Text className="text-heading text-textPrimary font-bold mb-8">Settings</Text>
 
         <View className="flex-row items-center justify-between mb-6">
-          <Text className="text-lg font-outfit">Hands-off Mode</Text>
+          <Text className="text-subtitle text-textPrimary">Hands-off Mode</Text>
           <Switch value={handsOff} onValueChange={setHandsOff} />
         </View>
 
+        <View className="flex-row items-center justify-between mb-6">
+          <Text className="text-subtitle text-textPrimary">Dark Mode</Text>
+          <Switch value={scheme === 'dark'} onValueChange={toggle} />
+        </View>
+
         <View className="mb-6">
-          <Text className="font-outfit mb-2">Trip Budget Limit</Text>
+          <Text className="text-body text-textPrimary mb-2">Trip Budget Limit</Text>
           <TextInput
             value={tripLimit}
             onChangeText={setTripLimit}
             placeholder="$"
             keyboardType="numeric"
-            className="border p-2 rounded"
+            className="border border-textSecondary p-2 rounded text-textPrimary"
           />
         </View>
 
         <View className="mb-6">
-          <Text className="font-outfit mb-2">Per Booking Limit</Text>
+          <Text className="text-body text-textPrimary mb-2">Per Booking Limit</Text>
           <TextInput
             value={bookingLimit}
             onChangeText={setBookingLimit}
             placeholder="$"
             keyboardType="numeric"
-            className="border p-2 rounded"
+            className="border border-textSecondary p-2 rounded text-textPrimary"
           />
         </View>
       </ScrollView>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,14 +2,13 @@ import 'setimmediate';
 import {
   DarkTheme,
   DefaultTheme,
-  ThemeProvider,
+  ThemeProvider as NavigationThemeProvider,
 } from "@react-navigation/native";
 import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect, useState } from "react";
 import "react-native-reanimated";
-import { useColorScheme } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import "../global.css";
 import "react-native-get-random-values";
@@ -23,11 +22,21 @@ import { auth } from "@/config/FirebaseConfig";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { CurrencyProvider } from "@/context/CurrencyContext";
 import { ChatProvider } from "@/context/ChatContext";
+import { ThemeModeProvider, useThemeContext } from "@/context/ThemeContext";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
+  return (
+    <ThemeModeProvider>
+      <RootNavigation />
+    </ThemeModeProvider>
+  );
+}
+
+function RootNavigation() {
+  const { scheme } = useThemeContext();
   const [tripData, setTripData] = useState<any[]>([]);
   const [itineraries, setItineraries] = useState<StoredItinerary[]>([]);
 
@@ -70,7 +79,6 @@ export default function RootLayout() {
     });
   };
 
-  const colorScheme = useColorScheme();
   const [loaded] = useFonts({
     outfit: require("@/assets/fonts/Outfit-Regular.ttf"),
     "outfit-medium": require("@/assets/fonts/Outfit-Medium.ttf"),
@@ -100,24 +108,30 @@ export default function RootLayout() {
   }
 
   return (
-    <CurrencyProvider>
-      <ChatProvider>
-        <CreateTripContext.Provider value={{ tripData, setTripData }}>
-        <ItineraryContext.Provider value={{ itineraries, addItinerary, removeItinerary }}>
-          <StatusBar style="dark" />
-          <Stack screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="index" />
-            <Stack.Screen name="(auth)" />
-            <Stack.Screen name="(tabs)" />
-            <Stack.Screen name="create-trip" />
-            <Stack.Screen
-              name="generate-trip"
-              options={{ headerShown: true, headerTitle: () => <HeaderLogo /> }}
-            />
-          </Stack>
-        </ItineraryContext.Provider>
-      </CreateTripContext.Provider>
-      </ChatProvider>
-    </CurrencyProvider>
+    <NavigationThemeProvider
+      value={scheme === 'dark' ? DarkTheme : DefaultTheme}
+    >
+      <CurrencyProvider>
+        <ChatProvider>
+          <CreateTripContext.Provider value={{ tripData, setTripData }}>
+            <ItineraryContext.Provider
+              value={{ itineraries, addItinerary, removeItinerary }}
+            >
+              <StatusBar style={scheme === 'dark' ? 'light' : 'dark'} />
+              <Stack screenOptions={{ headerShown: false }}>
+                <Stack.Screen name="index" />
+                <Stack.Screen name="(auth)" />
+                <Stack.Screen name="(tabs)" />
+                <Stack.Screen name="create-trip" />
+                <Stack.Screen
+                  name="generate-trip"
+                  options={{ headerShown: true, headerTitle: () => <HeaderLogo /> }}
+                />
+              </Stack>
+            </ItineraryContext.Provider>
+          </CreateTripContext.Provider>
+        </ChatProvider>
+      </CurrencyProvider>
+    </NavigationThemeProvider>
   );
 }

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+import { ColorSchemeName, useColorScheme } from 'react-native';
+
+interface ThemeContextValue {
+  scheme: ColorSchemeName;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  scheme: 'light',
+  toggle: () => {},
+});
+
+export const ThemeModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const system = useColorScheme();
+  const [scheme, setScheme] = useState<ColorSchemeName>(system ?? 'light');
+
+  const value = useMemo(
+    () => ({
+      scheme,
+      toggle: () => setScheme((s) => (s === 'dark' ? 'light' : 'dark')),
+    }),
+    [scheme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useThemeContext = () => useContext(ThemeContext);

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,0 +1,22 @@
+export const colors = {
+  primary: '#312e81', // deep indigo
+  surface: '#fdfcf9', // warm cream
+  cardBg: '#ffffff',
+  textPrimary: '#111827',
+  textSecondary: '#6b7280',
+  accent: '#0d9488',
+  error: '#ef4444',
+};
+
+// Tailwind config helper
+export const tailwindColors = {
+  primary: colors.primary,
+  surface: colors.surface,
+  cardBg: colors.cardBg,
+  textPrimary: colors.textPrimary,
+  textSecondary: colors.textSecondary,
+  accent: colors.accent,
+  error: colors.error,
+};
+
+export default colors;

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,0 +1,14 @@
+export const typography = {
+  fontFamily: 'Inter',
+  heading: 24,
+  subtitle: 18,
+  body: 14,
+};
+
+export const tailwindFontSizes = {
+  heading: ['24px', '32px'],
+  subtitle: ['18px', '24px'],
+  body: ['14px', '20px'],
+};
+
+export default typography;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,8 @@
 /** @type {import('tailwindcss').Config} */
+require('ts-node').register();
+const { tailwindColors } = require('./src/theme/colors');
+const { tailwindFontSizes } = require('./src/theme/typography');
+
 module.exports = {
   // NOTE: Update this to include the paths to all of your component files.
   content: ["./app/**/*.{js,jsx,ts,tsx}", "./components/**/*.{js,jsx,ts,tsx}"],
@@ -6,20 +10,10 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        outfit: ["outfit", "sans-serif"],
-        "outfit-medium": ["outfit-medium", "sans-serif"],
-        "outfit-bold": ["outfit-bold", "sans-serif"],
+        sans: ['Inter', 'sans-serif'],
       },
-      colors: {
-        primary: "#9C00FF",
-        secondary: "#DE00FF",
-        background: "#F9F5FF",
-        "text-primary": "#1E1B4B",
-        accent: "#B347FF",
-        "accent-hover": "#7F00CC",
-        success: "#22C55E",
-        alert: "#EF4444",
-      },
+      colors: tailwindColors,
+      fontSize: tailwindFontSizes,
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add color and typography theme tokens
- introduce theme context with light/dark mode and apply to app layout
- overhaul tab navigation and add placeholder Home/Plan/Nearby/Guides screens

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Jest encountered an unexpected token in @react-native/js-polyfills)*

------
https://chatgpt.com/codex/tasks/task_e_68be9502776c8324bcc41ef6a3e74c9f