### PR TITLE
Hide extra tabs from bottom navigation

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -71,6 +71,13 @@ export default function TabLayout() {
           ),
         }}
       />
+      {/* Hide routes that should not appear in the tab bar */}
+      <Tabs.Screen name="index" options={{ href: null }} />
+      <Tabs.Screen name="chat" options={{ href: null }} />
+      <Tabs.Screen name="guides" options={{ href: null }} />
+      <Tabs.Screen name="itineraries" options={{ href: null }} />
+      <Tabs.Screen name="nearby" options={{ href: null }} />
+      <Tabs.Screen name="profile" options={{ href: null }} />
     </Tabs>
   );
 }


### PR DESCRIPTION
## Summary
- Hide non-essential tab routes so bottom menu only shows core screens

## Testing
- `npm test -- --watchAll=false` *(fails: Unexpected identifier 'ErrorHandler')*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bff34b35c48324b8735e307c3f3f02