### PR TITLE
refactor: drop react-i18next usage

### DIFF
--- a/components/ChatQuickActions.tsx
+++ b/components/ChatQuickActions.tsx
@@ -1,19 +1,30 @@
 import React from "react";
 import { View, Button } from "react-native";
-import { useTranslation } from "react-i18next";
+import i18n from "../src/i18n";
 
 interface ChatQuickActionsProps {
   onSelect: (prompt: string) => void;
 }
 
 export default function ChatQuickActions({ onSelect }: ChatQuickActionsProps) {
-  const { t } = useTranslation();
   return (
     <View className="flex-row gap-2 mt-2 flex-wrap">
-      <Button title={t("quick.shift")!} onPress={() => onSelect("shift dates +2d")} />
-      <Button title={t("quick.shorten")!} onPress={() => onSelect("shorten") } />
-      <Button title={t("quick.budget")!} onPress={() => onSelect("budget ≤ €1200")} />
-      <Button title={t("quick.gems")!} onPress={() => onSelect("add hidden gems")} />
+      <Button
+        title={i18n.t("quick.shift")}
+        onPress={() => onSelect("shift dates +2d")}
+      />
+      <Button
+        title={i18n.t("quick.shorten")}
+        onPress={() => onSelect("shorten")}
+      />
+      <Button
+        title={i18n.t("quick.budget")}
+        onPress={() => onSelect("budget ≤ €1200")}
+      />
+      <Button
+        title={i18n.t("quick.gems")}
+        onPress={() => onSelect("add hidden gems")}
+      />
     </View>
   );
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,10 +1,12 @@
 import i18n from "i18next";
-import { initReactI18next } from "react-i18next";
 import * as Localization from "expo-localization";
 import en from "./en.json";
 import et from "./et.json";
 
-void i18n.use(initReactI18next).init({
+// Initialize i18next without the react-i18next adapter. This keeps the
+// configuration lightweight and avoids requiring the unused
+// "react-i18next" package, which was causing a bundler resolution error.
+void i18n.init({
   resources: {
     en: { translation: en },
     et: { translation: et },


### PR DESCRIPTION
## Summary
- replace useTranslation hook with direct i18n.t calls in ChatQuickActions
- initialize i18next without react-i18next adapter to avoid missing module

## Testing
- `npm test -- --watchAll=false` (fails: SyntaxError in @react-native/js-polyfills)
- `npm run lint` (fails: Unable to resolve path to module 'i18next' and others)


------
https://chatgpt.com/codex/tasks/task_e_68c02af9d3688324901eb3caa0e525f1