### PR TITLE
fix: avoid Hermes require error

### DIFF
--- a/packages/notify/index.ts
+++ b/packages/notify/index.ts
@@ -85,7 +85,10 @@ export async function notify(
   if (useMock) {
     try {
       const isNode =
-        typeof process !== 'undefined' && (process as any)?.versions?.node;
+        typeof process !== 'undefined' &&
+        (process as any)?.versions?.node &&
+        !(typeof navigator === 'object' && navigator.product === 'ReactNative');
+
       if (isNode) {
         const fs: any = (eval('require') as any)('fs');
         const path: any = (eval('require') as any)('path');


### PR DESCRIPTION
## Summary
- avoid accessing Node-only `require` on Hermes by detecting React Native and skipping fs usage

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c11f2c8ec88324aa968950e8e75408